### PR TITLE
docs: refactor structure in vs code and contribution guideline

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -98,7 +98,15 @@ export default defineConfig({
         "label": "JetBrains Gateway",
         "link": "/tools/jetbrains-gateway/"
       }]
-    },],
+    },
+    {
+      "label": "Contribution",
+      "items": [{
+        "label": "Guideline",
+        "link": "/contribution/guidelines",
+      }]
+    }
+  ],
     customCss: ["./src/styles/tailwind.css"]
   }),
 ]

--- a/src/content/docs/contribution/guidelines.mdx
+++ b/src/content/docs/contribution/guidelines.mdx
@@ -1,0 +1,121 @@
+---
+
+title: Contribution Guidelines(TBC)
+description: This guide will walk you through how to install and set up Daytona's VS Code extension, discuss features included with VS Code extension, and a clean uninstall guide is also included
+sidebar:
+  label: Guidelines
+---
+import {Tabs, TabItem, CardGrid, LinkCard } from "@astrojs/starlight/components"
+
+Welcome to Daytona's documentation contribution guideline, where we believe that well-crafted documentation is essential to building a vibrant and collaborative open-source community. Your contribution to our documentation plays a pivotal role in helping developers, users, and enthusiasts understand, use, and contribute to Daytona effectively. 
+
+This guide serves as a comprehensive resource to help you contribute in a meaningful way, covering the **fundamental principles of documentation**, **the recommended structure for content**, **best practices in content writing**, and guidance on using **consistent terminologies**. Whether you're a seasoned technical writer or just getting started, your efforts in improving our documentation are invaluable. Before you begin, thank you for considering to be a part of the Daytona's journey.
+
+## Principals
+
+In our documentation, we follow several principals:
+- **Simplicity is a virtue**
+
+Only keeps the **ABSOLUTE NECESSITY**. If things can be described by words, you don't need images. If a title can be in 2 words, don't make it 4. Overloading a documentation with images tend to overwhelm readers, so as long titles on the right sidebar. **Avoid redundancy** whereas possible but make sure readers understand when they are performing an action, what they might see, where this action should be and what's next for them. Simplicity should not lead to confusion. If the right sidebar already render the subtitle, you don't need to put `<a href="#content"> content </a>` to highlight it again in the content body.
+- **Straight to the point**
+
+If a title can't correctly capture what the content is discussing, rewrite it. If an action is too simple which carries too little information, add more information to make sure users know where they are at and make it clear. 
+- **Visually pleasing**
+
+If there are options of the same action, try to use a `Tab` component: 
+
+<Tabs>
+<TabItem label="Option 1">
+Option 1 content
+</TabItem>
+<TabItem label="Option 2">
+Option 2 content
+</TabItem>
+</Tabs>
+
+If there are things that `Readers might need to know`, try to use a togglable component. 
+
+<div class="not-content">
+<details >
+<summary>Togglable summary title</summary>
+<div class="content">
+Toggalable content
+</div>
+</details>
+</div>
+
+If there is a dangerous action which might lead to destructive result(for example, deleting a configuration file on a user's local machine), make sure you double check the facts and try to use a caution callout card. 
+:::caution
+Things should be paid extra attention 
+:::
+
+
+__To write good documentation, you can follow these steps:__
+> 1. Draft. On the first draft, write them as detailed as possible
+> 2. Research and fact-check
+> 3. Polishing facts and write more 
+> 4. Double check 
+> 5. Mercilessly trim redundant content
+> 6. Leave it for a while and come back again to make sure everything is logical
+> 7. Repeat from step 2 to step 5.
+> 8. Test locally `pnpm run dev` (although some might prefer to have live view from step 1)
+> 9. Create PR<br/>
+
+## Structure
+---
+### Best practices for SEO 
+When you are creating a sub-section in a documentation. By default the top level is two hash symbol. Do follow a top-down approach and starting with two hash symbols like `##` and then add more hash symbols under each section. On rendering, two hash symbols will be resolved to `<h2>` element in the browser and vice versa. It will help search engines understand how the website is structured and it's content.
+
+### Adding documentation
+All the documentation related content sit in the folder `/src/content/docs`. A [folder] will be resolved to a togglable button on the left, and an [*.md] or [*.mdx] file will be resolved to its respective sub sections.
+
+### Left sidebar
+To correctly rendering all documentations, you will need to go to the file `astro.config.mjs` in the root directory and add the `label` and `link` to the respective directory under `siderbar`: 
+
+```javascript
+
+"sidebar": [{
+      "label": "Getting Started",
+      link: 'getting-started'
+    }, {
+      "label": "Architecture",
+      link: 'architecture'
+    }, {
+      "label": "Installation",
+      "items": [{
+        "label": "Single Node",
+        "link": "/installation/single-node/"
+      }, {
+        "label": "Cluster",
+        "link": "/installation/cluster/"
+      },
+        ...
+
+```
+
+### Right sidebar
+The right sidebar helps readers navigate within the current content, and only `##` and `###` will be rendered on the right sidebar. 
+
+**Keep the title short**: Long title is not great for reading. If a title can be `Establishing a connection`, you don't need `Establishing a connection with VS Code and Daytona installation for the first time` as your title. If a sub-section can be `Creating repository`, you don't need to number it like `1. Creating repository`. 
+
+**Avoid long actions**: If it is an action including multiple steps (say more than 3), don't include the steps in the right sidebar but use asterisk `**` to **highlight it in the content**. Long steps may overwhelm readers. If there are sub-steps included in steps of actions, separating the step and sub-step's bulleting by `1, 2, 3...` and `a, b, c...` to avoid confusion.
+
+
+
+
+## Content
+
+
+
+## Terminologies
+
+Some useful terms when you are considering contributing and help you align with our semantics.
+
+**Workspace**: Repositories created within Daytona are called `Workspace`. Whenever you want to refer to the usage of repository, use `Workspace`
+
+---
+<CardGrid>
+  <LinkCard title="⭐️ Give us a star" href="https://github.com/daytonaio/installer" />
+  <LinkCard title="📝 Contribute to this doc" href="https://github.com/daytonaio/docs/pulls?q=is:pr+is:open+sort:updated-desc" /> 
+  <LinkCard title="🙋 Join our Slack community" href="https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q" />
+</CardGrid>

--- a/src/content/docs/contribution/guidelines.mdx
+++ b/src/content/docs/contribution/guidelines.mdx
@@ -53,7 +53,7 @@ Things should be paid extra attention
 __To write good documentation, you can follow these steps:__
 > 1. Draft. On the first draft, write them as detailed as possible
 > 2. Research and fact-check
-> 3. Polishing facts and write more 
+> 3. Polishing facts and write more. Don't trust anyone but your own testing and research.
 > 4. Double check 
 > 5. Mercilessly trim redundant content
 > 6. Leave it for a while and come back again to make sure everything is logical

--- a/src/content/docs/tools/vs-code-extension.mdx
+++ b/src/content/docs/tools/vs-code-extension.mdx
@@ -173,7 +173,10 @@ To remove Daytona-specific entries from your SSH configuration without deleting 
 ```bash
 nano ~/.ssh/config
 ```
-> If you use `nano` might notice that you mouse is not working here and that's **expected in a terminal**. You can only move around with arrow keys ⬆️⬇️⬅️➡️, and delete content using [Delete] key.
+
+:::tip
+If you use `nano`, you might notice that you mouse is not working here and that's **expected in a terminal**. You can only move cursor around with arrow keys ⬆️⬇️⬅️➡️, and delete content using [Delete] key.
+:::
 
 Or if you prefer using VS Code as your editor:
 ```bash

--- a/src/content/docs/tools/vs-code-extension.mdx
+++ b/src/content/docs/tools/vs-code-extension.mdx
@@ -14,18 +14,7 @@ Daytona's VS Code extension integrating Visual Studio Code and Daytona, appearin
 
 The extension allows you to have a frictionless experience of opening a standardised development environment, creating repositories and accessing your [Daytona Workspaces](/usage/workspaces). It offers convenient repository management, profile control, and instant team information access -- all directly within VS Code, removing the hassle of going to a web browser, open Daytona URL and creating projects upon initial configuration.
 
-
-##### This guide includes 5 sections: 
-
-**[Prerequisites](#prerequisite)**: What you need to have to get Daytona's VS Code extension working as expected<br/>
-**[How to install](#how-to-install)**: How to install Daytona VS Code extension<br/>
-**[Establish a connection for the first time](#establish-connection)**: After installing Daytona VS Code extension, how to get it working<br/>
-**[Features](#features)**: Introducing what you can do with VS Code extension -- workspaces, teams, profiles<br/>
-**[Clean Uninstall Guide](#clean-uninstall)**: What to do if you want to start over again.
-
-
-
-<a href="#prerequisite" class="content-subtitle">
+<a href="#prerequisites" class="content-subtitle">
 ## Prerequisites
 </a>
 Before you can harness the full potential of Daytona's VS Code extension, make sure you meet the following prerequisites to allow a smooth installation process:
@@ -37,7 +26,6 @@ Before you can harness the full potential of Daytona's VS Code extension, make s
 With these prerequisites in place, you'll be ready to set up Daytona's VS Code extension.
 
 
-
 <a href="#how-to-install" class="content-subtitle">
 ## How to install
 </a>
@@ -47,7 +35,10 @@ Installing the Daytona VS Code extension is simple. You have two options to choo
 
 <Tabs>
 <TabItem label="Download from URL">
-Install from [Daytona VS Code Extension](https://marketplace.visualstudio.com/items?itemName=daytonaio.daytona)
+1. **Navigate to browser**: In your browser, navigate to [Daytona VS Code Extension](https://marketplace.visualstudio.com/items?itemName=daytonaio.daytona) in VS Code extension market place. 
+2. **Click on install**: Click on the green button `Install` on the website from the last step
+3. **Continue to VS Code**: Once you click on `Install`, the browser will have a pop up window "Visual Studio Code is required to install this extension.", if you have everything listed in <a href="#prerequisites">prerequisites</a> just choose "Continue".
+4. **Open "Code":** In the browser, the pop up window will ask 'marketplace.visualstudio.com' wants to open "Code", choose 'Open "Code"'.
 </TabItem>
 <TabItem label="Download in VS Code Extension Marketplace">
 
@@ -63,14 +54,10 @@ MacOS: `Command+Shift+X`
 _🚩 Now you should see your Daytona VS Code extension displayed on the left-hand side of VS Code. But when you click on it, nothing is displayed under "WORKSPACES", "TEAMS", "PROFILES", now what?_
 
 
-<a href="#establish-connection" class="content-subtitle">
-## Establish a connection for the first time
-</a>
+### Establish a connection
 When you are using the VS Code extension for the first time, you will need to establish a safe connection between your local computer and your Daytona instance. Having this connection in place is essential whenever you are using Daytona VS Code extension in the future, it keeps your workspaces, profiles and teams sync with your Daytona installation. We will walk you through it step by step, and you will need your **[Daytona dashboard URL](#prerequisite)** before we continue.
 
-<span class="content-subtitle">
-### Step 1. **Sign in to dashboard and open a repository**
-</span>
+**1. Sign in to dashboard and open a repository**: 
    - Visit your Daytona dashboard URL and make sure you are on the `WORKSPACES` tab.
    - Select one of the repositories and click on the "𓈓" icon next to one of your repositories.
    - Under the dropdown menu, select "Open".
@@ -86,44 +73,42 @@ When you are using the VS Code extension for the first time, you will need to es
 </details>
 </div>
 
-<span class="content-subtitle">
-### Step 2. **Configure default code editor**
-</span>
+
+**2. Configure default code editor**
+
    - Within daytona dashboard, after you selected "Open", choose "VS Code" as your code editor in the pop up modal (You may choose others, but in this guide we will need VS Code).
-<span class="content-subtitle">
-### Step 3. **Respond to permissions**
-</span>
+
+**3. Respond to permissions**
+
    - As you proceed, you may encounter the following prompts within VS Code:
      - "The extension 'Daytona' wants to sign in using 'your-profile-name'." Choose the blue button with "Allow."
      - "Do you want Code to open the external website?" Choose "Open."
-<span class="content-subtitle">
-### Step 4. **Authenticate Daytona with Your Git provider**
-</span>
+
+**4. Authenticate Daytona with Your Git provider**
+
    - In the browser pop-up window that appears with "id.your-daytona-url" under "Please re-authenticate to continue," click on your Git provider.
-<span class="content-subtitle">
-### Step 5. **Open Visual Studio Code**
-</span>
+
+**5. Open Visual Studio Code**
+
    - In your browser, the pop-up will prompt "'id.your-daytona-url' wants to open 'Visual Studio Code'," choose one of the "Open 'Visual Studio Code'" options.
-<span class="content-subtitle">
-### Step 6. **Allow Daytona Extension**
-</span>
+
+**6. Allow Daytona Extension**
+
    - When VS Code is opened, you will be asked, "Allow 'Daytona' extension to open this URI?" Choose the blue button "Open".
-<span class="content-subtitle">
-### Step 7. **Select SSH Configuration File**
-</span>
+
+**7. Select SSH Configuration File**
+
    - Finally, in your VS Code, when prompted to "Select the SSH config file to update," choose the first option, usually in the format of `/User/name/.ssh/config`.
 
 _Congrats! You just established a safe connection between VS Code and your Daytona installation. Behind the scenes, we are also setting up the configuration files in your local computer. Your selected repository should be up and running in Visual Studio Code 🚀._
 
-<a href="#features" class="content-subtitle">
 ## Features
-</a>
 
 In this section, we'll cover the essential functionalities of the Daytona VS Code extension. These features are designed to simplify your development process, allowing for ease of cloud-based development, effortless repository creation and synchronization, viewing team information and creating profiles. 
 
 The functionalities are compatible with what you able to achieve in Daytona dashboard, be it creating, managing repositories, managing teams, viewing profiles. 
 
-### 1. Creating repositories
+### Creating repositories
 Each repositories created are isolated in their own environment, even if they live on the same branch. In the following two sub-sections, we will talk about how to create and manage your repositories with Daytona in VS Code.
  - **Click on `+`**: To create a repository, first you will need to click on the "+" button when you hover over the **Workspace** tab
  - **Repository URL**: You will be asked for a repository URL. On Github, you can obtain this URL by clicking on the green button "Clone, open or download", choose "Local" -> "Clone" via HTTPS on your repository page or adding `.git` after your repository's URL string
@@ -131,7 +116,7 @@ Each repositories created are isolated in their own environment, even if they li
  - **Checking repositories**: Once the repository is created, you can see them under `WORKSPACES` in the Daytona VS Code extension tab. We will talk about how to manage them in the next part. 
  - **Choosing base environment**: At the moment, if you want to create a repository with a preset template (ex: You are developing a [Go](https://go.dev/) project and prefer to have [Golang](https://go.dev/) pre-installed in the environment), you will need to go to your Daytona dashboard in the `Workspaces` tab and choose one of the templates. But if you have a `devcontainer.json` file describes the specific of your development environment, they will be set up as specified when you are creating, or opening a repository.
 
-### 2. Managing repositories
+### Managing repositories
 - **Synchronisation**: All the repositories under **[WORKSPACES](/usage/workspace)** in VS Code extension are synchronised with your Daytona dashboard, whether you are creating a repository by pressing "Create" on `WORKSPACES` tab in Daytona dashboard, or click `+` on `WORKSPACES` in Daytona VS Code extension, they will all sync together under the same team. 
 - **Opening repository**: To start working on a repository, you can hover on top of the repository's name and click on "Open", or right click on the repository to select "Open". It will start building the development container remotely. Upon finishing, you can work on it locally.
 - **Copy ID**: The same repositories might be created under different environment and if they are using the same name, it will become confusing to recognise for you or your team members. To make notes or recognise different repositories, right click on one of them and click "Copy ID". Your repository's ID will always be in the format of 
@@ -147,23 +132,21 @@ your-repository-name + random string
 - **Destroy a repository**: When you right click on a repository and select "Destroy", this behavior is irreversible. It removes the development container completely. If you have previous installation or set up that wasn't specified in [devcontainer.json](https://www.daytona.io/dotfiles/guide-create-devcontainer-json-file), you will lose them. When you recreate the repository from your Git provider, you will have to set them up, or reinstall them again. 
 :::
 
-### 3. Managing teams
+### Managing teams
 Repositories are separated between teams. Repositories created within a team only exists in that team, if you create a new team the `WORKSPACES` will appear empty. 
 - **Team information**: Within the Daytona extension tab, you can see your team's name under `TEAMS`.
 - **Creating a team**: At the moment you can only create a new team on your Daytona dashboard. 
 - **Selecting a team**: If you want to change a team -- hover over a team's name, and click on the `Select` button. Note that if you change a team, you won't see the same repositories you can see in the previous team.
 {/* need more information related to selecting a team */}
 
-### 4. Managing profiles
+### Managing profiles
 Profiles are equivalent to a fresh, new Daytona instance installation, however if you change your profile without changing teams, the repositories' created might appear the same under `WORKSPACES` section. But they are indeed being created in different environment when you open them.
 - **Checking profile**: Under the `PROFILES` section within the extension, you can check your existing profile. Under each profile, you can see `API URL`, `Auth URL`, `SSH Port` and `Notification URL`
 - **Selecting profile**: If you want to change your profile, you can do so by hovering over your profile's name and choose `Select`, when you open a repository under `WORKSPACE` after choosing a new profile, your repositories will be opened in different environment. Different from clicking on `Destroy` after right click on a repository under `WORKSPACES`, the previous installation and dependencies within the same repository will persist.
 
 
 
-<a href="#clean-uninstall" class="content-subtitle">
 ## Clean Uninstall Guide
-</a>
 After installing Daytona VS Code extension, there might be a point when you update your Daytona instance's installation, or you want to start over the installation process again after a clean uninstall, here are several steps to help you to start fresh again: 
 <span class="content-subtitle">
 ### Step 1: Uninstall Daytona VS Code extension
@@ -179,9 +162,7 @@ And search for `Daytona` in the extension marketplace, select the extension with
 ### Step 2: Remove related directories and files related to Daytona
 </span>
 
-<span class="content-subtitle">
-### Step 2: Remove related directories and files related to Daytona
-</span>
+
 
 **Remove SSH configuration entries**<br/>
 To remove Daytona-specific entries from your SSH configuration without deleting the entire file, you will need to manually edit the file:
@@ -191,17 +172,19 @@ To remove Daytona-specific entries from your SSH configuration without deleting 
 ```bash
 nano ~/.ssh/config
 ```
+> If you use `nano` might notice that you mouse is not working here and that's **expected in a terminal**. You can only move around with arrow keys ⬆️⬇️⬅️➡️, and delete content using [Delete] key.
+
 Or if you prefer using VS Code as your editor:
 ```bash
 code ~/.ssh/config
 ```
 
 2. Locate the `Host` entries related to Daytona, which might be marked with comments such as `# START DAYTONA` and `# END DAYTONA`.
-3. Carefully remove only those lines related to Daytona.
+3. If you use `nano` might notice that you mouse is not working here and that's **expected in terminal**. You can only move around with Carefully remove only those lines related to Daytona.
 4. Save the changes and close the text editor.
 
-:::Note 
-Be very cautious not to remove other SSH configurations that are unrelated to Daytona, as they may be important for your other connections.
+:::caution
+Be very cautious not to remove other SSH configurations that are unrelated to Daytona, as they may be important for your other remote connections.
 :::
 
 **Remove profile related data**<br/>

--- a/src/content/docs/tools/vs-code-extension.mdx
+++ b/src/content/docs/tools/vs-code-extension.mdx
@@ -23,7 +23,7 @@ Before you can harness the full potential of Daytona's VS Code extension, make s
 - **Daytona**: Daytona's power lies in its infrastructure. If you haven't set it up yet, you can easily do so by [downloading it from the Daytona installer](https://github.com/daytonaio/installer)
 - **Daytona Dashboard URL**: To complete the setup, you'll need the URL of your Daytona dashboard, which you can obtain from installing from [Daytona installer](https://github.com/daytonaio/installer).
 
-With these prerequisites in place, you'll be ready to set up Daytona's VS Code extension.
+_With these prerequisites in place, you'll be ready to set up Daytona's VS Code extension._
 
 
 <a href="#how-to-install" class="content-subtitle">
@@ -35,19 +35,22 @@ Installing the Daytona VS Code extension is simple. You have two options to choo
 
 <Tabs>
 <TabItem label="Download from URL">
-1. **Navigate to browser**: In your browser, navigate to [Daytona VS Code Extension](https://marketplace.visualstudio.com/items?itemName=daytonaio.daytona) in VS Code extension market place. 
-2. **Click on install**: Click on the green button `Install` on the website from the last step
-3. **Continue to VS Code**: Once you click on `Install`, the browser will have a pop up window "Visual Studio Code is required to install this extension.", if you have everything listed in <a href="#prerequisites">prerequisites</a> just choose "Continue".
-4. **Open "Code":** In the browser, the pop up window will ask 'marketplace.visualstudio.com' wants to open "Code", choose 'Open "Code"'.
+1. **Navigate to browser:** In your browser, navigate to [Daytona VS Code Extension](https://marketplace.visualstudio.com/items?itemName=daytonaio.daytona) in VS Code extension market place. 
+2. **Click on install:** Click on the green button `Install` on the website from the last step
+3. **Continue to VS Code:** Once you click on `Install`, the browser will have a pop up window "Visual Studio Code is required to install this extension.", if you have everything listed in <a href="#prerequisites">prerequisites</a> just choose "Continue".
+4. **Open "Code":** In the browser, the pop up window will ask 'marketplace.visualstudio.com' wants to open "Code", choose 'Open "Code"'. Next you will be redirected to VS Code.
+5. **Choose `Install`:** On the tab `Extensions: Daytona`, click on the `Install` button.
+
 </TabItem>
 <TabItem label="Download in VS Code Extension Marketplace">
 
-**Step 1**: Open VS Code, navigate to the Extension tab in VS Code or use the shortcut keys:
+1. **Open VS Code:** Within VS Code, navigate to the Extension tab in VS Code or use the shortcut keys:
+   - Windows: `Ctrl+Shift+X`<br/>
+   - MacOS: `Command+Shift+X`
 
-Windows: `Ctrl+Shift+X`<br/>
-MacOS: `Command+Shift+X`
+2. **Search "Daytona":** Within VS Code's extension tab, search "Daytona" in the extension market place, you will find the extension with our logo. 
 
-**Step 2**: Search "Daytona" in the extension market place, you will find the extension with our logo. Hit `Install` either on the extension or on the window `Extensions: Daytona`
+3. **Click "Install":** Within VS Code, hit `Install` either on the extension or on the window `Extensions: Daytona`
 </TabItem>
 </Tabs>
 
@@ -119,11 +122,7 @@ Each repositories created are isolated in their own environment, even if they li
 ### Managing repositories
 - **Synchronisation**: All the repositories under **[WORKSPACES](/usage/workspace)** in VS Code extension are synchronised with your Daytona dashboard, whether you are creating a repository by pressing "Create" on `WORKSPACES` tab in Daytona dashboard, or click `+` on `WORKSPACES` in Daytona VS Code extension, they will all sync together under the same team. 
 - **Opening repository**: To start working on a repository, you can hover on top of the repository's name and click on "Open", or right click on the repository to select "Open". It will start building the development container remotely. Upon finishing, you can work on it locally.
-- **Copy ID**: The same repositories might be created under different environment and if they are using the same name, it will become confusing to recognise for you or your team members. To make notes or recognise different repositories, right click on one of them and click "Copy ID". Your repository's ID will always be in the format of 
-
-```
-your-repository-name + random string
-```
+- **Copy ID**: The same repositories might be created under different environment and if they are using the same name, it will become confusing to recognise for you or your team members. To make notes or recognise different repositories, right click on one of them and click "Copy ID". Your repository's ID will always be in the format of `your-repository-name + random string`
 
 
 - **Stopping a repository**: Right click on the repository and select "Stop", it will stop development container and the remote connection with your Daytona instance. When you need to come back and work on it again, you just need to click "Open"
@@ -148,8 +147,10 @@ Profiles are equivalent to a fresh, new Daytona instance installation, however i
 
 ## Clean Uninstall Guide
 After installing Daytona VS Code extension, there might be a point when you update your Daytona instance's installation, or you want to start over the installation process again after a clean uninstall, here are several steps to help you to start fresh again: 
+
+
 <span class="content-subtitle">
-### Step 1: Uninstall Daytona VS Code extension
+### Uninstall Daytona VS Code extension
 </span>
 In VS Code, navigate to the Extension tab in VS Code or use the shortcut keys:
 
@@ -159,15 +160,15 @@ MacOS: `Command+Shift+X`
 And search for `Daytona` in the extension marketplace, select the extension with our logo and click on the blue button `Uninstall` on the `Extensions:Daytona` tab that shows up. This will only remove the extension within VS Code, for a clean uninstall you will need to continue to the next step.
 
 <span class="content-subtitle">
-### Step 2: Remove related directories and files related to Daytona
+### Remove Daytona related files
 </span>
 
 
 
-**Remove SSH configuration entries**<br/>
+**Remove SSH configuration entries:**
 To remove Daytona-specific entries from your SSH configuration without deleting the entire file, you will need to manually edit the file:
 
-1. Open the SSH configuration file in a text editor:
+**a. Open the SSH configuration file in a text editor:**
 
 ```bash
 nano ~/.ssh/config
@@ -179,15 +180,17 @@ Or if you prefer using VS Code as your editor:
 code ~/.ssh/config
 ```
 
-2. Locate the `Host` entries related to Daytona, which might be marked with comments such as `# START DAYTONA` and `# END DAYTONA`.
-3. If you use `nano` might notice that you mouse is not working here and that's **expected in terminal**. You can only move around with Carefully remove only those lines related to Daytona.
-4. Save the changes and close the text editor.
+**b. Find content related to Daytona:** Locate the `Host` entries related to Daytona, which might be marked with comments, start with `# START DAYTONA` and ended with `# END DAYTONA`.
+
+Carefully remove only those lines related to Daytona.
+
+**c. Save changes:**. Save the changes and close the text editor.
 
 :::caution
 Be very cautious not to remove other SSH configurations that are unrelated to Daytona, as they may be important for your other remote connections.
 :::
 
-**Remove profile related data**<br/>
+##### Remove profile related data
 ```bash
 rm -rf ~/.daytona
 ```

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,5 @@
+
+
 .cursor-pointer {
     cursor: pointer;
     pointer-events: all;
@@ -11,6 +13,14 @@
 }
 
 .content-subtitle h3 {
+    padding-top:1.5rem;
+    padding-bottom:0.8rem;
+    /* padding-left:0.5rem; */
+    font-size:1.2rem;
+ 
+}
+
+.content-subtitle h4 {
     padding-top:1.5rem;
     padding-bottom:0.8rem;
     /* padding-left:0.5rem; */
@@ -35,6 +45,14 @@ h3 {
     border-radius: 0.5rem;
     color:aliceblue;
     padding:3%;
+}
+
+:root[data-theme="light"].not-content details {
+    color: rgb(26, 26, 26)
+}
+
+:root[data-theme="dark"].not-content details {
+    color: aliceblue;
 }
 
 .not-content details > summary {


### PR DESCRIPTION
Changes: 

**VS Code extension**: 
- Remove redundant inline sections in content that's already on right sidebar
- Remove long sub-section describing detailed steps in `Establishing a connection`
- Added information in `Download extension from URL` toggle
- Refactor long steps from right sidebar and only highlight them using `**`
- Move `Establish a connection` to the sub-section of `Installation` but not a top-level section
- Inline style formatting
- Added "tips for using nano" in case reader never used it.

**Contribution guideline**: 
Based on previous communication and loom video, I made a contribution guideline so conversation won't need to be repetitive. It is still WIP. Will add more in later PRs.