### PR TITLE
Removed Uninstall and Domains

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -31,12 +31,6 @@ export default defineConfig({
       }, {
         "label": "IDPs",
         "link": "/installation/idps/"
-      }, {
-        "label": "Domains",
-        "link": "/installation/domains/"
-      }, {
-        "label": "Uninstall",
-        "link": "/installation/uninstall/"
       }]
     }, {
       "label": "Configuration",

--- a/src/content/docs/installation/domains.md
+++ b/src/content/docs/installation/domains.md
@@ -1,6 +1,0 @@
----
-title: Domains Installation
-description: Add a brief description of the Domains Installation page here
-sidebar:
-  label: Domains
----

--- a/src/content/docs/installation/uninstall.md
+++ b/src/content/docs/installation/uninstall.md
@@ -1,6 +1,0 @@
----
-title: Uninstall
-description: Add a brief description of the Uninstall page here
-sidebar:
-  label: Uninstall
----


### PR DESCRIPTION
As both sections are part of the installation process and specific to Single or Cluster it makes no sense to have seperate sections in docs