### PR TITLE
docs: fix incorrect command and add CLI link

### DIFF
--- a/src/content/docs/usage/workspaces.md
+++ b/src/content/docs/usage/workspaces.md
@@ -49,10 +49,10 @@ Daytona workspaces simplify the setup and configuration of development environme
 1. **Starting Creation**: In your terminal use the following command:
 
 ```bash
-daytona Create
+daytona create
 ```
 
-2. **More Information**: Please refer to the CLI documentation for more information
+2. **More Information**: Please refer to the [CLI documentation](/docs/tools/cli) for more information
 
 ### Creation States
 


### PR DESCRIPTION
This PR:
- [x] Fixes an incorrect CLI command (`daytona Create` produces an error)
- [x] Adds a hyperlink to the CLI documentation (because I'm lazy 😛)