### PR TITLE
Remove dead link to Targets documentation on homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -45,11 +45,6 @@ import DocumentListItem from "@components/DocumentListItem.astro";
     href="/configuration/git-providers#adding-a-git-provider"
   />
   <DocumentListItem
-    title="Add a remote Docker target"
-    subtitle="Deploy your Dev Environments on a remote host using Docker."
-    href="/configuration/targets#adding-a-docker-target"
-  />
-  <DocumentListItem
     title="Set your default IDE"
     subtitle="Automatically open your Dev Environments in Visual Studio Code and a selection of JetBrains IDEs."
     href="/usage/dev-environments#setting-the-default-ide"


### PR DESCRIPTION
As discussed in #1, this will return in a future PR.