### PR TITLE
Update Dev Container to node@22

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,4 @@
 # Based on https://github.com/withastro/astro/blob/main/.devcontainer/Dockerfile
-FROM mcr.microsoft.com/devcontainers/javascript-node:0-18
-
-# Enable corepack for yarn
-RUN corepack enable
+FROM mcr.microsoft.com/devcontainers/javascript-node:22
 
 COPY welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     },
     "remoteUser": "root",
     "postCreateCommand": "yarn install",
+    "postStartCommand": "yarn start",
     "waitFor": "postCreateCommand",
     "customizations": {
       "codespaces": {
@@ -14,5 +15,6 @@
         "extensions": ["astro-build.astro-vscode",
          "esbenp.prettier-vscode"]
       }
-    }
+    },
+    "forwardPorts": [4321]
   }


### PR DESCRIPTION
The Dev Container config and Dockerfile were broken due to a recent dependency update requiring a newer version of Node.

This commit fixes #14 by updating the container image to node@22, and adds the `postStartCommand` hook and port forwarding config for Astro.