### PR TITLE
Add port forwarding procedures to Dev Environments page

### DIFF
--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -122,3 +122,57 @@ __Procedure__
 :::note
 When using the `daytona code` command with `VS Code - Browser` as your default IDE, Daytona will install OpenVSCode Server inside your project, forward the appropriate port to your local machine, and open your default browser automatically.
 :::
+
+### Forward Ports from a Workspace
+Daytona supports flexible port forwarding, allowing you to access services running in a Workspace locally or via a shareable public URL.
+With port forwarding, you can work on your project in a Workspace and test your code externally.
+
+#### Access a Port Locally
+You can access services running in a Workspace on your local machine.
+
+__Prerequisites__
+*   A working installation of Daytona.
+*   A running Workspace with at least 1 service accessible via TCP/UDP.
+
+__Procedure__
+1.  Execute the following command to forward a port from a running Workspace to your local machine:
+    ```shell
+    daytona forward <PORT> <WORKSPACE> <PROJECT>
+    ```
+
+    __Example: allow local access to port 4321 of the `example-dev-env` Workspace__
+    ```shell
+    daytona forward 4321 example-dev-env
+    ```
+
+#### Access a Port via Public URL
+You can access services running in a Workspace via a generated public URL.
+This allows you to share your work with others in real-time.
+
+:::note
+This feature uses a free public proxy service hosted by Daytona Platforms, Inc.
+By using this feature, you acknowledge that your data is processed in accordance with Daytona's [Privacy Policy](https://www.daytona.io/company/privacy-policy) and [Terms of Service](https://www.daytona.io/company/terms-of-service).
+:::
+
+__Prerequisites__
+*   A working installation of Daytona.
+*   A running Workspace with at least 1 service accessible via TCP/UDP.
+
+__Procedure__
+1.  Execute the following command to generate a public URL for a port on a running Workspace:
+    ```shell
+    daytona forward <PORT> <WORKSPACE> <PROJECT> --public
+    ```
+
+    __Example: generate a URL to access port 4321 of the `example-dev-env` Workspace__
+    ```shell
+    daytona forward 4321 example-dev-env --public
+    ```
+
+:::tip
+Alternatively, you can generate a public URL by executing the following command in a Workspace's shell:
+
+```shell
+daytona forward <PORT> --public
+```
+:::


### PR DESCRIPTION
Adds procedures for forwarding ports from a Dev Environment to a local machine, and generating a shareable URL.

Fixes #11.