### PR TITLE
Fix broken links on home page

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -42,12 +42,12 @@ import DocumentListItem from "@components/DocumentListItem.astro";
   <DocumentListItem
     title="Add a Git Provider"
     subtitle="Create Workspaces from repositories hosted across GitHub, GitLab, Bitbucket, and others."
-    href="/configuration/git-providers#adding-a-git-provider"
+    href="/configuration/git-providers#add-a-git-provider"
   />
   <DocumentListItem
     title="Add a remote Docker target"
     subtitle="Deploy your Workspaces on a remote host using Docker."
-    href="/configuration/targets#adding-a-docker-target"
+    href="/configuration/providers#add-a-target"
   />
   <DocumentListItem
     title="Set your default IDE"


### PR DESCRIPTION
After some previous PRs, some of the links on the Docs home page stopped functioning. This PR fixes them.