### PR TITLE
Fix broken changelog link in the Footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,7 @@ import ThemeSelect from "./ThemeSelect.astro";
         </p>
         <p>
             <Fragment set:html={textArrowIcon} />Latest project
-            updates? - <a href="https://github.com/daytonaio/daytona/releases/tag/v0.16.0.">View Changelog</a>
+            updates? - <a href="https://github.com/daytonaio/daytona/releases/tag/v0.16.0">View Changelog</a>
         </p>
         <p>
             <Fragment set:html={textArrowIcon} />Dotfiles Insider


### PR DESCRIPTION
While this is still static, it'll change once we start publishing the OSS changelog to https://daytona.io/changelog.

In the meantime, this is a quick fix so the link isn't broken.