### PR TITLE
Add --host to Astro server commands in package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "type": "module",
   "version": "0.16.0",
   "scripts": {
-    "dev": "astro dev",
-    "start": "astro dev",
+    "dev": "astro dev --host",
+    "start": "yarn run dev",
     "build": "astro build",
-    "preview": "astro preview",
+    "preview": "astro preview --host",
     "astro": "astro"
   },
   "dependencies": {


### PR DESCRIPTION
When using Astro's in-built dev/preview servers through `package.json` scripts, they should listen on all interfaces by default.

This commit also makes the `start` script an alias of `dev` to cut down on duplication.

Fixes #52.