### PR TITLE
docs: update server docs link

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -65,6 +65,6 @@ import DocumentListItem from "@components/DocumentListItem.astro";
   <DocumentListItem
     title="Daytona Server"
     subtitle="Learn about the Daytona Server and how to manually configure it."
-    href="reference/server"
+    href="usage/server"
   />
 </DocumentList>


### PR DESCRIPTION
Minor broken link on the docs homepage, go to /docs and check [the link to server docs](https://www.daytona.io/docs/#:~:text=to%20increase%20productivity.-,Daytona%20Server,-Learn%20about%20the).