### PR TITLE
fix: Some links are broken at daytona.io documentation page

### DIFF
--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -20,7 +20,7 @@ Daytona abstracts the management and deployment of Workspaces into 2 related con
     Daytona allows you to configure new and existing Targets, and choose between them at Workspace creation time.
 
 Daytona's architecture decentralizes the role of a Provider into a separate service.
-The [Daytona Server](/reference/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
+The [Daytona Server](/usage/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
 
 This makes it possible to create new Providers to govern Workspace management on any platform or hosting providers.
 

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -10,7 +10,7 @@ import Aside from '@components/Aside.astro'
 Daytona abstracts the management and deployment of Workspaces into 2 related concepts:
 
 1. **Provider**  
-    A plugin that interfaces with the [Daytona Server](../usage/server), responsible for Workspace deployment and lifecycle management.
+    A plugin that interfaces with the [Daytona Server](/usage/server), responsible for Workspace deployment and lifecycle management.
     Examples of platforms Providers may connect with include:
     - Container management platforms such as Docker or Podman;
     - Cloud hosting providers such as AWS or DigitalOcean.

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -10,7 +10,7 @@ import Aside from '@components/Aside.astro'
 Daytona abstracts the management and deployment of Workspaces into 2 related concepts:
 
 1. **Provider**  
-    A plugin that interfaces with the [Daytona Server](../reference/server), responsible for Workspace deployment and lifecycle management.
+    A plugin that interfaces with the [Daytona Server](/reference/server), responsible for Workspace deployment and lifecycle management.
     Examples of platforms Providers may connect with include:
     - Container management platforms such as Docker or Podman;
     - Cloud hosting providers such as AWS or DigitalOcean.
@@ -20,7 +20,7 @@ Daytona abstracts the management and deployment of Workspaces into 2 related con
     Daytona allows you to configure new and existing Targets, and choose between them at Workspace creation time.
 
 Daytona's architecture decentralizes the role of a Provider into a separate service.
-The [Daytona Server](../reference/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
+The [Daytona Server](/reference/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
 
 This makes it possible to create new Providers to govern Workspace management on any platform or hosting providers.
 

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -10,7 +10,7 @@ import Aside from '@components/Aside.astro'
 Daytona abstracts the management and deployment of Workspaces into 2 related concepts:
 
 1. **Provider**  
-    A plugin that interfaces with the [Daytona Server](/reference/server), responsible for Workspace deployment and lifecycle management.
+    A plugin that interfaces with the [Daytona Server](../usage/server), responsible for Workspace deployment and lifecycle management.
     Examples of platforms Providers may connect with include:
     - Container management platforms such as Docker or Podman;
     - Cloud hosting providers such as AWS or DigitalOcean.

--- a/src/content/docs/installation/installation.mdx
+++ b/src/content/docs/installation/installation.mdx
@@ -15,7 +15,7 @@ import ScriptPowerShell from "./method/script-powershell.mdx";
 You can install Daytona on [Linux](#linux), [macOS](#macos), and [Windows](#windows) systems.
 Each operating system supports both x86_64 and AArch64 architectures.
 
-After installing Daytona using the best method for your environment, you can [create a Workspace](../usage/workspaces#create-a-workspace), [add a Git Provider](../configuration/git-providers#add-a-git-provider), [install a Provider](../configuration/providers#install-a-provider), and [use the CLI reference](../reference/cli) to understand Daytona's full array of functionality.
+After installing Daytona using the best method for your environment, you can [create a Workspace](/usage/workspaces#create-a-workspace), [add a Git Provider](/configuration/git-providers#add-a-git-provider), [install a Provider](/configuration/providers#install-a-provider), and [use the CLI reference](/reference/cli) to understand Daytona's full array of functionality.
 
 ## Linux
 

--- a/src/content/docs/reference/cli.mdx
+++ b/src/content/docs/reference/cli.mdx
@@ -11,7 +11,7 @@ You can use the `daytona` tool for the following operations:
 
 * Managing the lifecycle of the Daytona Server.
 * Managing [Workspaces](/usage/workspaces), [Git Providers](/configuration/git-providers), [Providers](/configuration/providers), and other Daytona components.
-* Configuring the [Daytona Server](./server) interactively.
+* Configuring the [Daytona Server](/usage/server) interactively.
 
 This reference lists all commands supported by the `daytona` command-line tool complete with a description of their behaviour, and any supported flags.
 You can access this documentation on a per-command basis by appending the `--help`/`-h` flag when invoking `daytona`.

--- a/src/content/docs/reference/cli.mdx
+++ b/src/content/docs/reference/cli.mdx
@@ -10,7 +10,7 @@ The `daytona` command-line tool provides access to Daytona's core features.
 You can use the `daytona` tool for the following operations:
 
 * Managing the lifecycle of the Daytona Server.
-* Managing [Workspaces](../usage/workspaces), [Git Providers](../configuration/git-providers), [Providers](../configuration/providers), and other Daytona components.
+* Managing [Workspaces](/usage/workspaces), [Git Providers](/configuration/git-providers), [Providers](/configuration/providers), and other Daytona components.
 * Configuring the [Daytona Server](./server) interactively.
 
 This reference lists all commands supported by the `daytona` command-line tool complete with a description of their behaviour, and any supported flags.

--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -37,19 +37,13 @@ Creating a Workspace allows you to set up a new environment either by selecting 
    daytona create
    ```
 
-
-2. Select the Git Provider and repository you want your Workspace to be configured with.
-3. Enter a name for your Workspace.
-   <Aside type="note">
-     You can press `F10` to configure advanced settings for your Workspace,
-     including setting the [Builder](/usage/builders).
-
    <Aside type="tip">
       You can open a new Workspace in an [IDE](/usage/ide) by using the `--code` flag.
 
       ```shell
       daytona create --code
       ```
+
    </Aside>
 
 2. Select the Git Provider you want to use or select to enter a custom repository URL. Daytona provides two options for linking your repository:
@@ -76,7 +70,7 @@ Creating a Workspace allows you to set up a new environment either by selecting 
 
    <Aside type="note">
      You can press `F10` to configure advanced settings for your Workspace,
-     including setting the [Builder](../usage/builders).
+     including setting the [Builder](/usage/builders).
    </Aside>
 
 5. Wait while Daytona sets up your Workspace. It handles all the initialization and configuration of your environment.
@@ -125,29 +119,10 @@ Creating a Workspace from an arbitrary Git URL allows you to set up a new enviro
       daytona   | Project daytona started
    ```
 
-<Aside type="tip">
-You can set the Project Builder at Workspace creation time using command-line flags.
-These flags only apply when creating Workspaces with a single Project.
-- To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags.
-- To use the Dev Container Builder, set the`--devcontainer-path` flag to the Dev Container configuration path within the repository.
-- To explicitly specify the Builder, set the`--builder` flag.
-    Accepted values are `auto`, `devcontainer`, or `none`.
-
-**Example**
-
-```shell
-daytona create <REPO_URL> --custom-image=daytona-workspace:latest --custom-image-user=daytona
-daytona create <REPO_URL> --devcontainer-path=.devcontainer/devcontainer.json
-daytona create <REPO_URL> --builder=auto
-```
-
-</Aside>
-
    <Aside type="tip">
    You can set the Project Builder at Workspace creation time using command-line
    flags. Refer to **[Builders](/usage/builders)** for more information.
    </Aside>
-
 
 ## List Workspaces
 

--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -33,7 +33,7 @@ You can create a Workspace.
 3. Enter a name for your Workspace.
    <Aside type="note">
      You can press `F10` to configure advanced settings for your Workspace,
-     including setting the [Builder](../usage/builders).
+     including setting the [Builder](/usage/builders).
    </Aside>
 4. Wait for Daytona to create the Workspace.
 
@@ -69,17 +69,19 @@ daytona create --code
 <Aside type="tip">
 You can set the Project Builder at Workspace creation time using command-line flags.
 These flags only apply when creating Workspaces with a single Project.
--   To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags.
--   To use the Dev Container Builder, set the`--devcontainer-path` flag to the Dev Container configuration path within the repository.
--   To explicitly specify the Builder, set the`--builder` flag.
+- To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags.
+- To use the Dev Container Builder, set the`--devcontainer-path` flag to the Dev Container configuration path within the repository.
+- To explicitly specify the Builder, set the`--builder` flag.
     Accepted values are `auto`, `devcontainer`, or `none`.
 
-__Example__
+**Example**
+
 ```shell
 daytona create <REPO_URL> --custom-image=daytona-workspace:latest --custom-image-user=daytona
 daytona create <REPO_URL> --devcontainer-path=.devcontainer/devcontainer.json
 daytona create <REPO_URL> --builder=auto
 ```
+
 </Aside>
 
 ## List Workspaces


### PR DESCRIPTION
# Some links are broken at daytona.io documentation page

# Description:

- This pull request addresses issues with relative links in the documentation. Specifically, it removes the usage of `..` in all paths, replacing them with absolute paths to ensure that links work correctly in both development and production environments.

# Related Issues:
Fixes #92 

# Screenshots:

Before : ![Screenshot (112)](https://github.com/user-attachments/assets/6c41cd7f-2450-4ec8-9abf-787c637885ee)

After: 
![Screenshot (111)](https://github.com/user-attachments/assets/7c5e2a5f-6694-4484-82b3-9249e4d999f5)
