### PR TITLE
fix: minor text whitespace formatting

### DIFF
--- a/src/content/docs/about/what-is-daytona.mdx
+++ b/src/content/docs/about/what-is-daytona.mdx
@@ -16,18 +16,29 @@ Daytona's functionality is exposed through a command-line tool that runs on Linu
 
 ## Features
 
-* __Security__  
+* __Security__
+
     Daytona creates a secure VPN connection between the client machine and the remote machine.
     All ports on the remote machine can be accessed securely without the need for manual port forwarding.
+
 * __Support for Visual Studio Code and JetBrains__
+
     Daytona supports both Visual Studio Code and the JetBrains line of IDEs, making it easy to develop your project while feeling like everything's local.
-* __Connect with GitHub, GitLab, Bitbucket, and Gitea__  
+
+* __Connect with GitHub, GitLab, Bitbucket, and Gitea__
+
     Daytona can create DEs by pulling repositories from your preferred SCM platform. Git operations can be executed within a workspace, allowing you to push your work without context switching.
-* __Support for Multi-Project Workspaces__  
+
+* __Support for Multi-Project Workspaces__
+
     Daytona is capable of creating workspaces with multiple projects.
     Large projects split into micro-services or multiple repositories can be worked on using a single workspace.
-* __Reverse Proxy Support__  
+
+* __Reverse Proxy Support__
+
     Daytona integrates a reverse proxy allowing you to access a workspace on a public or restricted network.
-* __Extensible Core__  
+
+* __Extensible Core__
+
     Daytona supports plugins developed in Go.
     Third-party Providers can be added to Daytona, as well as extensions to core functionality.


### PR DESCRIPTION
- fixed minor text whitespace formatting issue in the [what is daytona](https://www.daytona.io/docs/about/what-is-daytona/) section

Current behavior:
<img width="670" alt="Screenshot 2024-07-30 at 12 16 37 AM" src="https://github.com/user-attachments/assets/d79506fe-dd6f-48cf-8430-594f8ded2f2c">

Expected behavior:
<img width="660" alt="Screenshot 2024-07-30 at 5 21 01 PM" src="https://github.com/user-attachments/assets/3ee58aa8-8d11-46e6-bc28-2536e77deb45">

