### PR TITLE
docs: modify support anchor tag hyperlink

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -11,7 +11,8 @@ import ThemeSelect from './ThemeSelect.astro'
 <footer class="docs-footer__container">
   <div class="docs-footer__container__support-links">
     <p>
-      <Fragment set:html={textArrowIcon} />Need help? - <a href="#"
+      <Fragment set:html={textArrowIcon} />Need help? - <a
+        href="https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q"
         >Reach support</a
       >
     </p>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -12,8 +12,7 @@ import ThemeSelect from './ThemeSelect.astro'
   <div class="docs-footer__container__support-links">
     <p>
       <Fragment set:html={textArrowIcon} />Need help? - <a
-        href="https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q"
-        >Reach support</a
+        href="https://go.daytona.io/slack">Reach support</a
       >
     </p>
     <p>


### PR DESCRIPTION
- modified "Need help? - Reach support" anchor tag hyperlink to link to daytona's slack community

This can be modified to link to any other support communication channel of preference (GitHub repository, issues, email, etc.)