### PR TITLE
docs: footer version reference package.json

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,9 +5,9 @@ import Default from '@astrojs/starlight/components/Footer.astro'
 import ThemeSelect from './ThemeSelect.astro'
 import { version } from '../../package.json'
 import { major, minor, patch } from 'semver'
-const [maj, min, pat] = [major(version), minor(version), patch(version)]
-const release = `${maj}.${min}.${pat}`
-const releaseLink = `https://github.com/daytonaio/daytona/releases/tag/v${release}`
+const [maj, min] = [major(version), minor(version)]
+const release = `${maj}.${min}`
+const releaseLink = `https://github.com/daytonaio/daytona/releases/tag/v${release}.0`
 ---
 
 <Default {...Astro.props}>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,6 +3,11 @@ import { Image } from 'astro:assets'
 import textArrowIcon from '@assets/icons/text-arrow.svg?raw'
 import Default from '@astrojs/starlight/components/Footer.astro'
 import ThemeSelect from './ThemeSelect.astro'
+import { version } from '../../package.json'
+import { major, minor, patch } from 'semver'
+const [maj, min, pat] = [major(version), minor(version), patch(version)]
+const release = `${maj}.${min}.${pat}`
+const releaseLink = `https://github.com/daytonaio/daytona/releases/tag/v${release}`
 ---
 
 <Default {...Astro.props}>
@@ -17,8 +22,7 @@ import ThemeSelect from './ThemeSelect.astro'
     </p>
     <p>
       <Fragment set:html={textArrowIcon} />Latest project updates? - <a
-        href="https://github.com/daytonaio/daytona/releases/tag/v0.24.0"
-        >View Changelog</a
+        href={releaseLink}>View Changelog</a
       >
     </p>
     <p>


### PR DESCRIPTION
- added version reference from package.json to footer
- fixes https://github.com/daytonaio/docs/issues/2

This eliminates the need to bump the release version in the footer for each new release. 

I will also try to do the same for the .mdx files so only package.json would need to be version bumped with each new release.