### PR TITLE
chore: update slack link to daytona redirect

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ To add a language, you will need its BCP-47 tag and a label. See [“Adding a ne
 
   You can find a list of supported browsers and their versions using this [browserslist query](https://browsersl.ist/#q=%3E+0.5%25%2C+not+dead%2C+Chrome+%3E%3D+88%2C+Edge+%3E%3D+88%2C+Firefox+%3E%3D+98%2C+Safari+%3E%3D+15.4%2C+iOS+%3E%3D+15.4%2C+not+op_mini+all). To check whether or not a feature is supported, you can visit the [Can I use](https://caniuse.com) website and search for the feature.
 
-[slack]: https://join.slack.com/t/slack-qvd5984/shared_invite/zt-26jeiddev-ay4B8dp0OvZGPqmmOOM_ug
+[slack]: https://go.daytona.io/slack
 [issues]: https://github.com/daytonaio/docs/issues
 [sl]: https://github.com/daytonaio/docs/pulls
 [api-docs]: https://docs.astro.build/en/reference/integrations-reference/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Daytona's user and developer documentation.
 <p align="center">
     <a href="https://github.com/daytonaio/docs/issues/new?assignees=&labels=bug">Report Bug</a>
     ·
-  <a href="https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q">Join Our Slack</a>
+  <a href="https://go.daytona.io/slack">Join Our Slack</a>
     ·
     <a href="https://twitter.com/daytonaio">Twitter</a>
   </p>
@@ -102,4 +102,4 @@ This project has adapted the Code of Conduct from the [Contributor Covenant](htt
 ## Questions
 
 If you need guideance on contributing to Daytona, talk to us on
-[Slack](https://join.slack.com/t/daytonacommunity/shared_invite/zt-273yohksh-Q5YSB5V7tnQzX2RoTARr7Q).
+[Slack](https://go.daytona.io/slack).


### PR DESCRIPTION
Updated the slack link from a static one to a Daytona redirect shortlink so we don't have to change the link once it expires.