### PR TITLE
Fix: Uninstall Command in Daytona Documentation

### DIFF
--- a/src/content/docs/installation/method/uninstall-macos.mdx
+++ b/src/content/docs/installation/method/uninstall-macos.mdx
@@ -17,14 +17,13 @@ Ensure you have a backup of any Workspace data and relevant configuration before
 
     ```shell
     daytona purge
-    sudo rm $(where daytona)
     ```
 
     Run the following commands if the `daytona purge` command does not work, or if you want to manually purge local Daytona data and remove the binary:
 
     ```shell
     rm -rf ~/Library/Application\ Support/daytona
-    sudo rm $(where daytona)
+    sudo rm $(whereis daytona | awk '{print $2}')
     ```
 
     Additionally, to fully remove all Daytona-related configurations and components, run the following command:

--- a/src/content/docs/installation/method/uninstall-unix.mdx
+++ b/src/content/docs/installation/method/uninstall-unix.mdx
@@ -4,7 +4,7 @@ title: Linux Uninstallation
 import Aside from "@components/Aside.astro";
 export const partial = true;
 
-You can uninstall Daytona after using the official installation script.
+You can uninstall Daytona by following this procedure.
 
 <Aside type="caution">
 This procedure is destructive and irreversible.
@@ -17,5 +17,31 @@ Ensure you have a backup of any Workspace data and relevant configuration before
 
     ```shell
     daytona purge
-    sudo rm $(where daytona)
     ```
+
+    Run the following commands if the `daytona purge` command does not work, or if you want to manually purge local Daytona data and remove the binary:
+
+    ```shell
+    rm -rf ~/Library/Application\ Support/daytona
+    sudo rm $(whereis daytona | awk '{print $2}')
+    ```
+
+    Additionally, to fully remove all Daytona-related configurations and components, run the following command:
+
+    ```shell
+    rm -f ~/.ssh/daytona_config
+    ```
+
+    Edit your `~/.ssh/config` file to remove the `Include daytona_config entry`. You can do this manually by running the following command:
+
+    ```shell
+    nano ~/.ssh/config
+    ```
+
+    Remove the local Daytona registry container by running the following command:
+
+    ```shell
+    docker rm /daytona-registry
+    ```
+
+    If you have generated any autocomplete scripts for Daytona, you will need to remove them manually from your shell configuration files (e.g., `.bashrc`, `.zshrc`).


### PR DESCRIPTION
### Fix Uninstall Command in Daytona Documentation

This PR resolves issue #90 by updating the uninstall instructions for both macOS and Unix systems.

- **Files changed**: `uninstall-macos.mdx`, `uninstall-unix.mdx`
- **Changes**:
  - Updated the uninstall command in `uninstall-macos.mdx` to `sudo rm $(whereis daytona | awk '{print $2}')`.
  - Made similar corrections in `uninstall-unix.mdx` to ensure accurate and consistent uninstall procedures.

This update ensures that users have the correct instructions for uninstalling `daytona` on both linux and macOS.