### PR TITLE
docs: add new providers

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -89,6 +89,13 @@ export default defineConfig({
                 icon: 'git-commit.svg',
               },
             },
+            {
+              label: 'Targets',
+              link: '/configuration/targets',
+              attrs: {
+                icon: 'tag.svg',
+              },
+            },
           ],
         },
         {

--- a/src/content/docs/about/getting-started.mdx
+++ b/src/content/docs/about/getting-started.mdx
@@ -159,26 +159,26 @@ By default, a Docker Provider is configured with `localhost` as the Target.
 
 You can install additional Providers to extend Daytona's capabilities and support a wide range of container management platforms and cloud hosting services.
 
-Follow the instructions provided in the [Providers installation](/configuration/providers#managing-providers) guide to install and manage a Provider. The guide includes detailed steps for installing Providers for various container management platforms and cloud hosting services.
+Follow the instructions provided in the [Providers installation](/configuration/providers) guide to install and manage a Provider. The guide includes detailed steps for installing Providers for various container management platforms and cloud hosting services.
 
 <DocumentList>
 <DocumentListItem
     title="Install a Provider"
     subtitle="Learn how to install a Provider and interface with the Daytona Server."
-    href="/configuration/providers#managing-providers"
+    href="/configuration/providers"
     expanded
   />
 </DocumentList>
 
 ## Setting a Target
 
-A [Target](/configuration/providers#managing-targets) refers to the specific destination or environment where your development setups, facilitated by various Providers, are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
+A [Target](/configuration/targets) refers to the specific destination or environment where your development setups, facilitated by various Providers, are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
 
 A Target can be a local machine, a remote server, or a cloud instance, and it can vary based on the chosen Provider. Targets offer the flexibility to deploy and manage environments across different platforms and accounts, all within the unified interface provided by Daytona.
 
 Once you set your Target, it becomes available for selection whenever you create a new development environment in Daytona. You can manage multiple Targets or delete those you no longer need.
 
-Follow the instructions provided in the [managing Targets](/configuration/providers#managing-targets) guide to set a Target and configure your development environment deployment settings.
+Follow the instructions provided in the [managing Targets](/configuration/targets) guide to set a Target and configure your development environment deployment settings.
 
 Use the `daytona target --help` command to view available configuration options for setting a Target.
 
@@ -186,7 +186,7 @@ Use the `daytona target --help` command to view available configuration options 
 <DocumentListItem
     title="Set a Target"
     subtitle="Learn how to set a Target to define how Daytona manages your development environment."
-    href="/configuration/providers#managing-targets"
+    href="/configuration/targets"
     expanded
   />
 </DocumentList>

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -115,7 +115,7 @@ Daytona allows you to uninstall an existing Provider, helping you manage your Pr
 
 ## Docker
 
-The Docker Provider allows Daytona to create Workspace projects as Docker containers. The Provider integrates Daytona with Docker, enabling you to manage Workspaces on a Docker instance. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
+The Docker Provider allows Daytona to create Workspace projects as Docker containers. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
 
 1. Run the following command to install a Docker Provider:
 

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -47,6 +47,24 @@ Daytona allows you to install a Provider to interface with the Daytona Server. O
         Provider docker-provider has been successfully installed
     ```
 
+## List Providers
+
+Daytona allows you to list all installed Providers, providing you with an overview of the Providers available for managing Workspaces.
+
+1. Run the following command to list all installed Providers:
+
+    ```shell
+    daytona provider list
+    ```
+
+    Upon running this command, Daytona will display a list of your installed Providers and their respective versions.
+
+    ```text
+        Name                                Version               
+        ───────────────────────────────────────────
+        docker-provider                     v.0.0.0
+   ```
+
 ## Update a Provider
 
 Daytona allows you to update an existing Provider, enabling you to apply the latest enhancements and bug fixes.

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -95,10 +95,33 @@ Daytona allows you to uninstall an existing Provider, helping you manage your Pr
 
 ## Docker
 
-After installation, Daytona installs a Provider for Docker (`daytona-provider-docker`) by default.
+Daytona installs a Provider for Docker (`docker-provider`) by default.
 A default Target using the Docker Provider is also added, allowing the creation of Workspaces on your local machine.
 
-### Add a Target
+1. Run the following command to install a Docker Provider:
+
+    ```shell
+    daytona provider install
+    ```
+
+    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
+
+2. Select `docker-provider` to install Docker as your Provider.
+
+    ```text
+        Choose a provider to install
+        ===
+        > docker-provider
+          v0.0.0
+    ```
+
+    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+
+    ```text
+        Provider docker-provider has been successfully installed
+    ```
+
+### Add Docker Target
 
 When using Docker as a Provider, you have the choice of creating either a local or remote [Target](/configuration/targets):
 
@@ -122,14 +145,17 @@ When following the [set a Target](/configuration/targets#set-a-target) procedure
 2. **Remote Hostname**
 
     The hostname of the remote host.
+
 3. **Remote Password**
 
     The password for the remote user.
     If password authentication is disabled on the remote host, you can choose an SSH key in the next step.
+
 4. **Remote Port**
 
     The TCP port used to access the remote host's SSH daemon.
     Unless otherwise configured on your remote host, this should be set to the default value (`22`)
+
 5. **Remote User**
 
      The username used to execute the required commands on the remote host.
@@ -146,7 +172,8 @@ When following the [set a Target](/configuration/targets#set-a-target) procedure
 6. **Sock Path**
 
     The Docker UNIX socket location on the remote host.
-    Unless otherwise configured after installing Docker, this should be set to the default value (`/var/run/docker.sock`)
+    Unless otherwise configured after installing Docker, this should be set to the default value (`/var/run/docker.sock`).
+
 7. **Remote Private Key Path**
 
     The SSH private key used to connect to the remote host.
@@ -155,17 +182,19 @@ When following the [set a Target](/configuration/targets#set-a-target) procedure
 #### Local
 
 By default, Daytona comes pre-configured with a local Docker Target.
-If you have removed the default Docker Target, you can recreate it using the [set a Target](/configuration/targets#set-a-target)procedure.
+If you have removed the default Docker Target, you can recreate it using the [set a Target](/configuration/targets#set-a-target) procedure.
 
 ## AWS
 
-The AWS Provider allows Daytona to create and manage Workspace projects on Amazon EC2 instances. This provider integrates Daytona with AWS, enabling you to deploy and manage Workspaces in a scalable and flexible cloud environment.
+The AWS Provider allows Daytona to create and manage Workspace projects on Amazon EC2 instances. The Provider integrates Daytona with AWS, enabling you to deploy and manage Workspaces in a scalable and flexible cloud environment.
 
 To use the AWS Provider, ensure that your AWS programmatic access user has the `AmazonEC2FullAccess` permissions. This policy grants the necessary permissions to manage EC2 instances, which is crucial for Daytona's Workspace project creation and management.
 
-### Add a Target
+### Add AWS Target
 
-The AWS Provider does not have any default Targets. You must create and configure a [Target](/configuration/targets#set-a-target) before using the Provider. Use the `daytona target set` command to set the Target with the AWS Provider.
+The AWS Provider does not have any default [Targets](/configuration/targets). You must create and configure a Target before using the Provider.
+
+1. Run the **`daytona target set`** command to set a Target for the AWS Provider.
 
 When setting up a Target for the AWS Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
 
@@ -184,13 +213,40 @@ These configuration options allow you to customize the AWS environment for your 
 
 Once a Target is set, you can use it to create and manage Workspaces on Amazon EC2 instances, leveraging the full capabilities of AWS for your projects.
 
+### Add AWS Provider
+
+1. Run the following command to install an AWS Provider:
+
+    ```shell
+    daytona provider install
+    ```
+
+    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
+
+2. Select `aws-provider` to install AWS as your Provider.
+
+    ```text
+        Choose a provider to install
+        ===
+        > aws-provider
+          v0.0.0
+    ```
+
+    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+
+    ```text
+        Provider aws-provider has been successfully installed
+    ```
+
 ## DigitalOcean
 
-The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. This provider integrates Daytona with DigitalOcean, enabling you to deploy and manage Workspaces on a flexible and scalable cloud platform.
+The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. The Provider integrates Daytona with DigitalOcean, enabling you to deploy and manage Workspaces on a flexible and scalable cloud platform.
 
-### Add a Target
+### Add DigitalOcean Target
 
-The DigitalOcean Provider does not have any default Targets. You must create and configure a [Target](/configuration/targets#set-a-target) before using the Provider. Use the `daytona target set` command to set the Target with the DigitalOcean Provider.
+The DigitalOcean Provider does not have any default [Targets](/configuration/targets). You must create and configure a Target before using the Provider.
+
+1. Run the **`daytona target set`** command to set a Target for the DigitalOcean Provider.
 
 When setting up a Target for the DigitalOcean Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
 
@@ -206,13 +262,40 @@ These configuration options allow you to customize the DigitalOcean environment 
 
 Once a Target is set, you can use it to create and manage Workspaces on DigitalOcean droplets, leveraging the full capabilities of DigitalOcean for your projects.
 
+### Add DigitalOcean Provider
+
+1. Run the following command to install a DigitalOcean Provider:
+
+    ```shell
+    daytona provider install
+    ```
+
+    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
+
+2. Select `digitalocean-provider` to install DigitalOcean as your Provider.
+
+    ```text
+        Choose a provider to install
+        ===
+        > digitalocean-provider
+          v0.0.0
+    ```
+
+    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+
+    ```text
+        Provider digitalocean-provider has been successfully installed
+    ```
+
 ## Fly
 
-The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known as Fly Machines. This provider integrates Daytona with the Fly.io platform, enabling you to deploy and manage Workspaces in a globally distributed cloud environment.
+The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known as Fly Machines. The Provider integrates Daytona with the Fly.io platform, enabling you to deploy and manage Workspaces in a globally distributed cloud environment.
 
-### Add a Target
+### Add Fly Target
 
-The Fly Provider does not have any default Targets. You must create and configure a [Target](/configuration/targets#set-a-target) before using the Provider. Use the `daytona target set` command to set the Target with the Fly Provider.
+The Fly Provider does not have any default [Targets](/configuration/targets). You must create and configure a Target before using the Provider.
+
+1. Run the **`daytona target set`** command to set a Target for the Fly Provider.
 
 When setting up a Target for the Fly Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
 
@@ -227,3 +310,28 @@ When setting up a Target for the Fly Provider, you will need to configure severa
 These configuration options allow you to customize the Fly.io environment for your Daytona Workspaces.
 
 Once a Target is set, you can use it to create and manage Workspaces on Fly Machines, leveraging the full capabilities of Fly.io for your projects.
+
+### Add Fly Provider
+
+1. Run the following command to install a Fly Provider:
+
+    ```shell
+    daytona provider install
+    ```
+
+    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
+
+2. Select `fly-provider` to install Fly as your Provider.
+
+    ```text
+        Choose a provider to install
+        ===
+        > fly-provider
+          v0.0.0
+    ```
+
+    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+
+    ```text
+        Provider fly-provider has been successfully installed
+    ```

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -7,30 +7,15 @@ sidebar:
 
 import Aside from '@components/Aside.astro'
 
-Daytona abstracts the management and deployment of Workspaces into 2 related concepts:
+Providers are plugins through which Daytona integrates with various technologies to create and manage development environments. Providers abstract complexities of underlying technologies and serve as the foundational engines that Daytona leverages to deploy and run your environments, whether through containerization, orchestration, or cloud-based virtual machines.
 
-1. **Provider**  
-    A plugin that interfaces with the [Daytona Server](/usage/server), responsible for Workspace deployment and lifecycle management.
-    Examples of platforms Providers may connect with include:
-    - Container management platforms such as Docker or Podman;
-    - Cloud hosting providers such as AWS or DigitalOcean.
-2. **Target**  
-    A set of configuration that governs how Daytona manages and deploys Workspaces.
-    Each Target is tied to an individual Provider.
-    Daytona allows you to configure new and existing Targets, and choose between them at Workspace creation time.
+Daytona's architecture decentralizes the role of a Provider into a separate service. The [Daytona Server](/usage/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
 
-Daytona's architecture decentralizes the role of a Provider into a separate service.
-The [Daytona Server](/usage/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
-
-This makes it possible to create new Providers to govern Workspace management on any platform or hosting providers.
-
-## Managing Providers
-
-### Install a Provider
+## Install a Provider
 
 Daytona allows you to install a Provider to interface with the Daytona Server. Once a new Provider is installed, it manages Workspace deployment and lifecycle management.
 
-1. Run the following command to start the guided Providers installation:
+1. Run the following command to install a Provider:
 
     ```shell
     daytona provider install
@@ -54,37 +39,13 @@ Daytona allows you to install a Provider to interface with the Daytona Server. O
         Select a specific version
     ```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces. You can now create a [Target](#managing-targets) to use with the created Provider.
+    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces. You can now create a [Target](/configuration/targets) to use with the created Provider.
 
     ```text
         Provider docker-provider has been successfully installed
     ```
 
-### Uninstall a Provider
-
-Daytona allows you to uninstall an existing Provider, helping you manage your Providers by removing those that are no longer needed.
-
-1. Run the following command to uninstall a Provider:
-
-    ```shell
-    daytona provider uninstall
-    ```
-
-2. Select the Provider you want to uninstall from the list.
-
-    ```text
-        Choose a provider to uninstall
-        1 item
-        ===
-        │ docker-provider
-        │ v0.0.0
-    ```
-
-    ```text
-        Provider docker-provider has been successfully uninstalled
-    ```
-
-### Update a Provider
+## Update a Provider
 
 Daytona allows you to update an existing Provider, enabling you to apply the latest enhancements and bug fixes.
 
@@ -100,142 +61,46 @@ Daytona allows you to update an existing Provider, enabling you to apply the lat
         Choose a provider to update
         1 item
         ===
-        │ docker-provider
-        │ v0.0.0
+        docker-provider
+        v0.0.0
     ```
 
     ```text
         Provider docker-provider has been successfully updated
     ```
 
-## Managing Targets
+## Uninstall a Provider
 
-### Set a Target
+Daytona allows you to uninstall an existing Provider, helping you manage your Providers by removing those that are no longer needed.
 
-Daytona allows you to set a Target to use when managing Workspaces.
-
-**Prerequisite**
-
-- **At least [one Provider installed](#managing-providers).**
-
-    Providers are essential for managing and deploying your Workspaces, so make sure you have configured at least one.
-
-1. Run the following command to set a Target:
+1. Run the following command to uninstall a Provider:
 
     ```shell
-    daytona target set
+    daytona provider uninstall
     ```
 
-2. Select the appropriate Provider for the environment you want to deploy to.
+2. Select the Provider you want to uninstall from the list.
 
     ```text
-        Choose a provider
+        Choose a provider to uninstall
         1 item
         ===
-        │ docker-provider
-        │ v0.0.0
-    ```
-
-3. Select `New Target`.
-4. Enter a name for your Target.
-5. Enter the appropriate configuration options when prompted.
-
-    ```text
-        Remote Password
-        >
-
-        Remote Port
-        >
-
-        Remote User
-        Note: non-root user required
-        >
-
-        Sock Path
-        > /var/run/docker.sock
-
-        Workspace Data Dir       
-        The directory on the remote host where the workspace data will be stored
-        > /tmp/daytona-data
-
-        Remote Private Key Path
-        daytona_config
-        known_hosts
-        Custom path
-        None
-    ```
-
-6. Click `Enter` to confirm setting the Target.
-
-    ```text
-        Target set successfully
-     ```
-
-### List Targets
-
-Daytona allows you to keep track of your Targets by listing all previously created Targets with their details.
-
-1. Run the following command to list currently set Targets:
-
-   ```shell
-   daytona target list
-   ```
-
-   Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the Provider it is connected to, and its configured options.
-
-   ```text
-    Target      Provider            Options
-    ───────────────────────────────────────────────────────────────────────
-    MyTarget    docker-provider     {
-                                        "Sock Path": "/var/run/docker.sock"
-                                    }
-   ```
-
-### Delete a Target
-
-Daytona allows you to delete Targets, helping you manage and remove those that are no longer needed. Once a Target is deleted, you will not be able to manage or deploy Workspaces on that Target.
-
-1. Run the following command:
-
-    ```shell
-    daytona target delete
-    ```
-
-    Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the unique identifier of the Workspace, and the repository it is connected to.
-
-2. Press `Enter` on the selected Target to delete it.
-
-    ```text
-        Choose a Target
-        1 item
-        ===
-        │ MyTarget          
-        │ docker-provider
-    ```
-
-3. Confirm the action.
-
-    ```text
-        ┃ Delete all workspaces within MyTarget?
-        ┃ You might not be able to easily remove these workspaces later.
-        ┃
-        ┃   [Yes]     [No]
+        docker-provider
+        v0.0.0
     ```
 
     ```text
-        Target MyTarget removed successfully
+        Provider docker-provider has been successfully uninstalled
     ```
 
-## Officially Supported Providers
-
-### Docker
+## Docker
 
 After installation, Daytona installs a Provider for Docker (`daytona-provider-docker`) by default.
 A default Target using the Docker Provider is also added, allowing the creation of Workspaces on your local machine.
 
-#### Add a Target
+### Add a Target
 
-When using Docker as a Provider, you have the choice of creating either a local or remote target:
+When using Docker as a Provider, you have the choice of creating either a local or remote [Target](/configuration/targets):
 
 - **[Remote](#remote)**  
   The target uses a remote installation of Docker to deploy Workspaces.
@@ -244,10 +109,10 @@ When using Docker as a Provider, you have the choice of creating either a local 
   The target uses your local installation of Docker to deploy Workspaces.
   This allows you to use Daytona without needing external servers or infrastructure.
 
-##### Remote
+#### Remote
 
 You can add a target for an installation of Docker on a remote host.
-When following the [Set a Target procedure](#set-a-target), note the following configuration options:
+When following the [set a Target](/configuration/targets#set-a-target) procedure, note the following configuration options:
 
 1. **Container Image**
 
@@ -287,20 +152,20 @@ When following the [Set a Target procedure](#set-a-target), note the following c
     The SSH private key used to connect to the remote host.
     If you are using password authentication, you can choose "None".
 
-##### Local
+#### Local
 
 By default, Daytona comes pre-configured with a local Docker Target.
-If you have removed the default Docker Target, you can recreate it using the [Set a Target procedure](#set-a-target).
+If you have removed the default Docker Target, you can recreate it using the [set a Target](/configuration/targets#set-a-target)procedure.
 
-### AWS Provider
+## AWS
 
 The AWS Provider allows Daytona to create and manage Workspace projects on Amazon EC2 instances. This provider integrates Daytona with AWS, enabling you to deploy and manage Workspaces in a scalable and flexible cloud environment.
 
 To use the AWS Provider, ensure that your AWS programmatic access user has the `AmazonEC2FullAccess` permissions. This policy grants the necessary permissions to manage EC2 instances, which is crucial for Daytona's Workspace project creation and management.
 
-#### Add a Target
+### Add a Target
 
-The AWS Provider does not have any default targets. You must create and configure a Target before using the Provider. Use the `daytona target set` command to set the Target with the AWS Provider.
+The AWS Provider does not have any default Targets. You must create and configure a [Target](/configuration/targets#set-a-target) before using the Provider. Use the `daytona target set` command to set the Target with the AWS Provider.
 
 When setting up a Target for the AWS Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
 
@@ -319,13 +184,13 @@ These configuration options allow you to customize the AWS environment for your 
 
 Once a Target is set, you can use it to create and manage Workspaces on Amazon EC2 instances, leveraging the full capabilities of AWS for your projects.
 
-### DigitalOcean Provider
+## DigitalOcean
 
 The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. This provider integrates Daytona with DigitalOcean, enabling you to deploy and manage Workspaces on a flexible and scalable cloud platform.
 
-#### Add a Target
+### Add a Target
 
-The DigitalOcean Provider does not have any default targets. You must create and configure a Target before using the Provider. Use the `daytona target set` command to set the Target with the DigitalOcean Provider.
+The DigitalOcean Provider does not have any default Targets. You must create and configure a [Target](/configuration/targets#set-a-target) before using the Provider. Use the `daytona target set` command to set the Target with the DigitalOcean Provider.
 
 When setting up a Target for the DigitalOcean Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
 
@@ -341,13 +206,13 @@ These configuration options allow you to customize the DigitalOcean environment 
 
 Once a Target is set, you can use it to create and manage Workspaces on DigitalOcean droplets, leveraging the full capabilities of DigitalOcean for your projects.
 
-### Fly Provider
+## Fly
 
 The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known as Fly Machines. This provider integrates Daytona with the Fly.io platform, enabling you to deploy and manage Workspaces in a globally distributed cloud environment.
 
-#### Add a Target
+### Add a Target
 
-The Fly Provider does not have any default targets. You must create and configure a Target before using the Provider. Use the `daytona target set` command to set the Target with the Fly Provider.
+The Fly Provider does not have any default Targets. You must create and configure a [Target](/configuration/targets#set-a-target) before using the Provider. Use the `daytona target set` command to set the Target with the Fly Provider.
 
 When setting up a Target for the Fly Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
 

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -6,6 +6,8 @@ sidebar:
 ---
 
 import Aside from '@components/Aside.astro'
+import DocumentList from "@components/DocumentList.astro";
+import DocumentListItem from "@components/DocumentListItem.astro";
 
 Providers are plugins through which Daytona integrates with various technologies to create and manage development environments. Providers abstract complexities of underlying technologies and serve as the foundational engines that Daytona leverages to deploy and run your environments, whether through containerization, orchestration, or cloud-based virtual machines.
 
@@ -95,8 +97,7 @@ Daytona allows you to uninstall an existing Provider, helping you manage your Pr
 
 ## Docker
 
-Daytona installs a Provider for Docker (`docker-provider`) by default.
-A default Target using the Docker Provider is also added, allowing the creation of Workspaces on your local machine.
+The Docker Provider allows Daytona to create Workspace projects on Docker containers. The Provider integrates Daytona with Docker, enabling you to manage Workspaces on a Docker instance. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
 
 1. Run the following command to install a Docker Provider:
 
@@ -118,102 +119,27 @@ A default Target using the Docker Provider is also added, allowing the creation 
     Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
     ```text
+        ⡿  Installing...
+    ```
+
+    ```text
         Provider docker-provider has been successfully installed
     ```
 
-### Add Docker Target
-
-When using Docker as a Provider, you have the choice of creating either a local or remote [Target](/configuration/targets):
-
-- **[Remote](#remote)**  
-  The target uses a remote installation of Docker to deploy Workspaces.
-  This requires access to an SSH daemon on the desired host machine, and access to a user with permission to create Docker containers.
-- **[Local](#local)**  
-  The target uses your local installation of Docker to deploy Workspaces.
-  This allows you to use Daytona without needing external servers or infrastructure.
-
-#### Remote
-
-You can add a target for an installation of Docker on a remote host.
-When following the [set a Target](/configuration/targets#set-a-target) procedure, note the following configuration options:
-
-1. **Container Image**
-
-    The base image used by Daytona to deploy new Workspaces.
-    The default value is `daytonaio/workspace-project`.
-
-2. **Remote Hostname**
-
-    The hostname of the remote host.
-
-3. **Remote Password**
-
-    The password for the remote user.
-    If password authentication is disabled on the remote host, you can choose an SSH key in the next step.
-
-4. **Remote Port**
-
-    The TCP port used to access the remote host's SSH daemon.
-    Unless otherwise configured on your remote host, this should be set to the default value (`22`)
-
-5. **Remote User**
-
-     The username used to execute the required commands on the remote host.
-
-    <br />
-
-    <Aside type="caution">
-      Non-root user is required so correct ownership is assumed inside the
-      project container.
-    </Aside>
-
-    <br />
-
-6. **Sock Path**
-
-    The Docker UNIX socket location on the remote host.
-    Unless otherwise configured after installing Docker, this should be set to the default value (`/var/run/docker.sock`).
-
-7. **Remote Private Key Path**
-
-    The SSH private key used to connect to the remote host.
-    If you are using password authentication, you can choose "None".
-
-#### Local
-
-By default, Daytona comes pre-configured with a local Docker Target.
-If you have removed the default Docker Target, you can recreate it using the [set a Target](/configuration/targets#set-a-target) procedure.
+<DocumentList>
+<DocumentListItem
+    title="Set a Docker Target"
+    subtitle="Learn how to set a local or remote Docker Target to deploy and manage Workspaces."
+    href="/configuration/targets#docker"
+    expanded
+  />
+</DocumentList>
 
 ## AWS
 
-The AWS Provider allows Daytona to create and manage Workspace projects on Amazon EC2 instances. The Provider integrates Daytona with AWS, enabling you to deploy and manage Workspaces in a scalable and flexible cloud environment.
+The AWS Provider allows Daytona to create and manage Workspace projects on Amazon EC2 instances. The Provider integrates Daytona with AWS, enabling you to manage Workspaces in a scalable and flexible cloud environment.
 
 To use the AWS Provider, ensure that your AWS programmatic access user has the `AmazonEC2FullAccess` permissions. This policy grants the necessary permissions to manage EC2 instances, which is crucial for Daytona's Workspace project creation and management.
-
-### Add AWS Target
-
-The AWS Provider does not have any default [Targets](/configuration/targets). You must create and configure a Target before using the Provider.
-
-1. Run the **`daytona target set`** command to set a Target for the AWS Provider.
-
-When setting up a Target for the AWS Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
-
-| Property           | Type   | Optional | Default Value  | Input Masked |
-|--------------------|--------|----------|----------------|--------------|
-| **Region**         | String | true     | us-east-1      | false        |
-| **Image Id**       | String | true     | ami-04a81a99f5ec58529 | false  |
-| **Instance Type**  | String | true     | t2.micro       | false        |
-| **Device Name**    | String | true     | /dev/sda1      | false        |
-| **Volume Size**    | String | true     | 10             | false        |
-| **Volume Type**    | String | true     | gp3            | false        |
-| **Access Key Id**  | String | false    |                | true         |
-| **Secret Access Key** | String | false |               | true         |
-
-These configuration options allow you to customize the AWS environment for your Daytona Workspaces.
-
-Once a Target is set, you can use it to create and manage Workspaces on Amazon EC2 instances, leveraging the full capabilities of AWS for your projects.
-
-### Add AWS Provider
 
 1. Run the following command to install an AWS Provider:
 
@@ -235,34 +161,25 @@ Once a Target is set, you can use it to create and manage Workspaces on Amazon E
     Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
     ```text
+        ⡿  Installing...
+    ```
+
+    ```text
         Provider aws-provider has been successfully installed
     ```
 
+<DocumentList>
+<DocumentListItem
+    title="Set an AWS Target"
+    subtitle="Learn how to set an AWS Target to deploy and manage Workspaces."
+    href="/configuration/targets#aws"
+    expanded
+  />
+</DocumentList>
+
 ## DigitalOcean
 
-The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. The Provider integrates Daytona with DigitalOcean, enabling you to deploy and manage Workspaces on a flexible and scalable cloud platform.
-
-### Add DigitalOcean Target
-
-The DigitalOcean Provider does not have any default [Targets](/configuration/targets). You must create and configure a Target before using the Provider.
-
-1. Run the **`daytona target set`** command to set a Target for the DigitalOcean Provider.
-
-When setting up a Target for the DigitalOcean Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
-
-| Property      | Type   | Optional | Default Value     | Input Masked |
-|---------------|--------|----------|-------------------|--------------|
-| **Auth Token**| String | true     |                   | true         |
-| **Disk Size** | Int    | false    | 20                | false        |
-| **Image**     | String | false    | ubuntu-22-04-x64  | false        |
-| **Region**    | String | false    | fra1              | false        |
-| **Size**      | String | false    | s-2vcpu-4gb       | false        |
-
-These configuration options allow you to customize the DigitalOcean environment for your Daytona Workspaces.
-
-Once a Target is set, you can use it to create and manage Workspaces on DigitalOcean droplets, leveraging the full capabilities of DigitalOcean for your projects.
-
-### Add DigitalOcean Provider
+The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. The Provider integrates Daytona with DigitalOcean, enabling you to manage Workspaces on a flexible and scalable cloud platform.
 
 1. Run the following command to install a DigitalOcean Provider:
 
@@ -284,34 +201,25 @@ Once a Target is set, you can use it to create and manage Workspaces on DigitalO
     Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
     ```text
+        ⡿  Installing...
+    ```
+
+    ```text
         Provider digitalocean-provider has been successfully installed
     ```
 
+<DocumentList>
+<DocumentListItem
+    title="Set a DigitalOcean Target"
+    subtitle="Learn how to set a DigitalOcean Target to deploy and manage Workspaces."
+    href="/configuration/targets#digitalocean"
+    expanded
+  />
+</DocumentList>
+
 ## Fly
 
-The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known as Fly Machines. The Provider integrates Daytona with the Fly.io platform, enabling you to deploy and manage Workspaces in a globally distributed cloud environment.
-
-### Add Fly Target
-
-The Fly Provider does not have any default [Targets](/configuration/targets). You must create and configure a Target before using the Provider.
-
-1. Run the **`daytona target set`** command to set a Target for the Fly Provider.
-
-When setting up a Target for the Fly Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
-
-| Property     | Type   | Optional | Default Value   | Input Masked |
-|--------------|--------|----------|-----------------|--------------|
-| **AuthToken**| String | false    |                 | true         |
-| **OrgSlug**  | String | false    |                 | false        |
-| **Region**   | String | true     |                 | false        |
-| **DiskSize** | String | true     | 10              | false        |
-| **Size**     | String | true     | shared-cpu-4x   | false        |
-
-These configuration options allow you to customize the Fly.io environment for your Daytona Workspaces.
-
-Once a Target is set, you can use it to create and manage Workspaces on Fly Machines, leveraging the full capabilities of Fly.io for your projects.
-
-### Add Fly Provider
+The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known as Fly Machines. The Provider integrates Daytona with the Fly.io platform, enabling you to manage Workspaces in a globally distributed cloud environment.
 
 1. Run the following command to install a Fly Provider:
 
@@ -333,5 +241,18 @@ Once a Target is set, you can use it to create and manage Workspaces on Fly Mach
     Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
     ```text
+        ⡿  Installing...
+    ```
+
+    ```text
         Provider fly-provider has been successfully installed
     ```
+
+<DocumentList>
+<DocumentListItem
+    title="Set a Fly Target"
+    subtitle="Learn how to set a Fly Target to deploy and manage Workspaces."
+    href="/configuration/targets#fly"
+    expanded
+  />
+</DocumentList>

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -40,10 +40,16 @@ Daytona allows you to install a Provider to interface with the Daytona Server. O
 
     ```text
         Choose a provider to install
-        1 item
+        5 items
         ===
-        │ docker-provider
-        │ v0.0.0
+        fly-provider
+        v0.0.0
+        aws-provider
+        v0.0.0
+        docker-provider
+        v0.0.0
+        digitalocean-provider
+        v0.0.0
 
         Select a specific version
     ```
@@ -263,10 +269,14 @@ When following the [Set a Target procedure](#set-a-target), note the following c
 
      The username used to execute the required commands on the remote host.
 
+    <br />
+
     <Aside type="caution">
       Non-root user is required so correct ownership is assumed inside the
       project container.
     </Aside>
+
+    <br />
 
 6. **Sock Path**
 
@@ -281,3 +291,74 @@ When following the [Set a Target procedure](#set-a-target), note the following c
 
 By default, Daytona comes pre-configured with a local Docker Target.
 If you have removed the default Docker Target, you can recreate it using the [Set a Target procedure](#set-a-target).
+
+### AWS Provider
+
+The AWS Provider allows Daytona to create and manage Workspace projects on Amazon EC2 instances. This provider integrates Daytona with AWS, enabling you to deploy and manage Workspaces in a scalable and flexible cloud environment.
+
+To use the AWS Provider, ensure that your AWS programmatic access user has the `AmazonEC2FullAccess` permissions. This policy grants the necessary permissions to manage EC2 instances, which is crucial for Daytona's Workspace project creation and management.
+
+#### Add a Target
+
+The AWS Provider does not have any default targets. You must create and configure a Target before using the Provider. Use the `daytona target set` command to set the Target with the AWS Provider.
+
+When setting up a Target for the AWS Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
+
+| Property           | Type   | Optional | Default Value  | Input Masked |
+|--------------------|--------|----------|----------------|--------------|
+| **Region**         | String | true     | us-east-1      | false        |
+| **Image Id**       | String | true     | ami-04a81a99f5ec58529 | false  |
+| **Instance Type**  | String | true     | t2.micro       | false        |
+| **Device Name**    | String | true     | /dev/sda1      | false        |
+| **Volume Size**    | String | true     | 10             | false        |
+| **Volume Type**    | String | true     | gp3            | false        |
+| **Access Key Id**  | String | false    |                | true         |
+| **Secret Access Key** | String | false |               | true         |
+
+These configuration options allow you to customize the AWS environment for your Daytona Workspaces.
+
+Once a Target is set, you can use it to create and manage Workspaces on Amazon EC2 instances, leveraging the full capabilities of AWS for your projects.
+
+### DigitalOcean Provider
+
+The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. This provider integrates Daytona with DigitalOcean, enabling you to deploy and manage Workspaces on a flexible and scalable cloud platform.
+
+#### Add a Target
+
+The DigitalOcean Provider does not have any default targets. You must create and configure a Target before using the Provider. Use the `daytona target set` command to set the Target with the DigitalOcean Provider.
+
+When setting up a Target for the DigitalOcean Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
+
+| Property      | Type   | Optional | Default Value     | Input Masked |
+|---------------|--------|----------|-------------------|--------------|
+| **Auth Token**| String | true     |                   | true         |
+| **Disk Size** | Int    | false    | 20                | false        |
+| **Image**     | String | false    | ubuntu-22-04-x64  | false        |
+| **Region**    | String | false    | fra1              | false        |
+| **Size**      | String | false    | s-2vcpu-4gb       | false        |
+
+These configuration options allow you to customize the DigitalOcean environment for your Daytona Workspaces.
+
+Once a Target is set, you can use it to create and manage Workspaces on DigitalOcean droplets, leveraging the full capabilities of DigitalOcean for your projects.
+
+### Fly Provider
+
+The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known as Fly Machines. This provider integrates Daytona with the Fly.io platform, enabling you to deploy and manage Workspaces in a globally distributed cloud environment.
+
+#### Add a Target
+
+The Fly Provider does not have any default targets. You must create and configure a Target before using the Provider. Use the `daytona target set` command to set the Target with the Fly Provider.
+
+When setting up a Target for the Fly Provider, you will need to configure several properties. Below is a breakdown of these properties, their types, and usage:
+
+| Property     | Type   | Optional | Default Value   | Input Masked |
+|--------------|--------|----------|-----------------|--------------|
+| **AuthToken**| String | false    |                 | true         |
+| **OrgSlug**  | String | false    |                 | false        |
+| **Region**   | String | true     |                 | false        |
+| **DiskSize** | String | true     | 10              | false        |
+| **Size**     | String | true     | shared-cpu-4x   | false        |
+
+These configuration options allow you to customize the Fly.io environment for your Daytona Workspaces.
+
+Once a Target is set, you can use it to create and manage Workspaces on Fly Machines, leveraging the full capabilities of Fly.io for your projects.

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -115,7 +115,7 @@ Daytona allows you to uninstall an existing Provider, helping you manage your Pr
 
 ## Docker
 
-The Docker Provider allows Daytona to create Workspace projects on Docker containers. The Provider integrates Daytona with Docker, enabling you to manage Workspaces on a Docker instance. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
+The Docker Provider allows Daytona to create Workspace projects as Docker containers. The Provider integrates Daytona with Docker, enabling you to manage Workspaces on a Docker instance. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
 
 1. Run the following command to install a Docker Provider:
 
@@ -197,7 +197,7 @@ To use the AWS Provider, ensure that your AWS programmatic access user has the `
 
 ## DigitalOcean
 
-The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as droplets. The Provider integrates Daytona with DigitalOcean, enabling you to manage Workspaces on a flexible and scalable cloud platform.
+The DigitalOcean Provider allows Daytona to create Workspace projects on DigitalOcean VMs, known as Droplets. The Provider integrates Daytona with DigitalOcean, enabling you to manage Workspaces on a flexible and scalable cloud platform.
 
 1. Run the following command to install a DigitalOcean Provider:
 

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -123,8 +123,6 @@ The Docker Provider allows Daytona to create Workspace projects as Docker contai
     daytona provider install
     ```
 
-    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
-
 2. Select `docker-provider` to install Docker as your Provider.
 
     ```text
@@ -165,8 +163,6 @@ To use the AWS Provider, ensure that your AWS programmatic access user has the `
     daytona provider install
     ```
 
-    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
-
 2. Select `aws-provider` to install AWS as your Provider.
 
     ```text
@@ -205,8 +201,6 @@ The DigitalOcean Provider allows Daytona to create Workspace projects on Digital
     daytona provider install
     ```
 
-    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
-
 2. Select `digitalocean-provider` to install DigitalOcean as your Provider.
 
     ```text
@@ -244,8 +238,6 @@ The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known a
     ```shell
     daytona provider install
     ```
-
-    Upon running this command, Daytona will prompt you to choose a Provider you want to install from the list.
 
 2. Select `fly-provider` to install Fly as your Provider.
 

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -1,0 +1,128 @@
+---
+title: Targets
+description: Learn how to manage Target configuration across Workspaces.
+sidebar:
+  label: Targets
+---
+
+A Target refers to the specific destination or environment where your development setups, facilitated by various [Providers](/configuration/providers), are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
+
+A Target can be a local machine, a remote server, or a cloud instance, and it can vary based on the chosen Provider. Targets offer the flexibility to deploy and manage environments across different platforms and accounts, all within the unified interface provided by Daytona.
+
+Once you set your Target, it becomes available for selection whenever you create a new development environment in Daytona. You can manage multiple Targets or delete those you no longer need.
+
+## Set a Target
+
+Daytona allows you to set a Target to use when managing Workspaces.
+
+**Prerequisite**
+
+- **At least [one Provider installed](/configuration/providers).**
+
+    Providers are essential for managing and deploying your Workspaces, so make sure you have configured at least one.
+
+1. Run the following command to set a Target:
+
+    ```shell
+    daytona target set
+    ```
+
+2. Select the appropriate Provider for the environment you want to deploy to.
+
+    ```text
+        Choose a provider
+        1 item
+        ===
+        docker-provider
+        v0.0.0
+    ```
+
+3. Select `New Target`.
+4. Enter a name for your Target.
+5. Enter the appropriate configuration options when prompted.
+
+    ```text
+        Remote Password
+        >
+
+        Remote Port
+        >
+
+        Remote User
+        Note: non-root user required
+        >
+
+        Sock Path
+        > /var/run/docker.sock
+
+        Workspace Data Dir       
+        The directory on the remote host where the workspace data will be stored
+        > /tmp/daytona-data
+
+        Remote Private Key Path
+        daytona_config
+        known_hosts
+        Custom path
+        None
+    ```
+
+6. Click `Enter` to confirm setting the Target.
+
+    ```text
+        Target set successfully
+     ```
+
+## List Targets
+
+Daytona allows you to keep track of your Targets by listing all previously created Targets with their details.
+
+1. Run the following command to list currently set Targets:
+
+   ```shell
+   daytona target list
+   ```
+
+   Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the Provider it is connected to, and its configured options.
+
+   ```text
+    Target      Provider            Options
+    ───────────────────────────────────────────────────────────────────────
+    MyTarget    docker-provider     {
+                                        "Sock Path": "/var/run/docker.sock"
+                                    }
+   ```
+
+## Delete a Target
+
+Daytona allows you to delete Targets, helping you manage and remove those that are no longer needed. Once a Target is deleted, you will not be able to manage or deploy Workspaces on that Target.
+
+1. Run the following command:
+
+    ```shell
+    daytona target delete
+    ```
+
+    Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the unique identifier of the Workspace, and the repository it is connected to.
+
+2. Press `Enter` on the selected Target to delete it.
+
+    ```text
+        Choose a Target
+        1 item
+        ===
+        MyTarget          
+        docker-provider
+    ```
+
+3. Confirm the action.
+
+    ```text
+        Delete all workspaces within MyTarget?
+        You might not be able to easily remove these workspaces later.
+        
+        [Yes]     [No]
+    ```
+
+    ```text
+        Target MyTarget removed successfully
+    ```

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -45,7 +45,7 @@ Daytona allows you to set a Target to use when managing Workspaces.
 
 3. Select `New Target`.
 4. Enter a name for your Target.
-5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Provider. The following example shows setting a remote Docker Target.
+5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Target. The following example shows setting a remote Docker Target.
 
     ```text
         Remote Password
@@ -160,7 +160,7 @@ Daytona allows you to set a Docker Target to use for deploying and managing Work
     - A remote machine uses a remote installation of Docker to deploy Workspaces and requires configuring the remote `password`, `port`, `user`, `sock path`, `Workspace data directory`, and `private key path`.
 
 4. Enter a name for your Target.
-5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Provider. The following example shows setting a local Docker Target.
+5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Target. The following example shows setting a local Docker Target.
 
     ```text
         Sock Path
@@ -203,21 +203,24 @@ Daytona allows you to set an AWS Target to use for deploying and managing Worksp
     >
 
     Region
-    The geographic area where AWS resourced are hosted. Default is us-east-1.
+    The geographic area where AWS resources are hosted. Default is us-east-1.
+    List of available regions https://docs.aws.amazon.com/general/latest/gr/rande.html
     > 
 
     Secret Access Key
-    If empty, it will be fetched from the AWS_SECRET_ACCESS_KEY environment variable.
+    Find this in the AWS Console under "My Security Credentials" (https://aws.amazon.com/premiumsupport/knowledge-center/manage-access-keys/).
+    Leave blank if you've set the AWS_SECRET_ACCESS_KEY environment variable, or enter your key here.
     >
 
     Volume Size
-    The size of the instance volume, in GB. Default is 20 GB. 
+    The size of the instance volume, in GB. Default is 20 GB.
     It is recommended that the disk size should be more than 20 GB.
+    List of volume size limits: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html
     >
 
     Volume Type
-    The type of volume. Default is gp3. 
-    List of available volume types https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html 
+    The type of volume. Default is gp3.
+    List of available volume types https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html
     >
     ```
 

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -45,7 +45,7 @@ Daytona allows you to set a Target to use when managing Workspaces.
 
 3. Select `New Target`.
 4. Enter a name for your Target.
-5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Target. The following example shows setting a remote Docker Target.
+5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Provider. The following example shows setting a remote Docker Target.
 
     ```text
         Remote Password

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -133,9 +133,9 @@ Daytona allows you to delete Targets, helping you manage and remove those that a
         Target MyTarget removed successfully
     ```
 
-## Docker
+## Docker (Local)
 
-Daytona allows you to set a Docker Target to use for deploying and managing Workspaces. The Docker Target enables you to deploy Workspaces on your local or remote machine using Docker.
+Daytona allows you to set a local Docker Target to use for deploying and managing Workspaces. The local Docker Target enables you to deploy Workspaces on your local machine using Docker.
 
 1. Run the following command to set a Target:
 
@@ -153,18 +153,85 @@ Daytona allows you to set a Docker Target to use for deploying and managing Work
         v0.0.0
     ```
 
-3. Select `local` to set a local Docker target, or `New Target` to set a remote Docker target.
+3. Select `local` to set a local Docker Target.
 
-    - A local machine uses your local installation of Docker to deploy Workspaces and requires configuring the `Sock Path` to the Docker socket.
-
-    - A remote machine uses a remote installation of Docker to deploy Workspaces and requires configuring the remote `password`, `port`, `user`, `sock path`, `Workspace data directory`, and `private key path`.
+    ```text
+        Choose a Target
+        1 item
+        ===
+        local
+        docker-provider
+    ```
 
 4. Enter a name for your Target.
-5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Target. The following example shows setting a local Docker Target.
+5. Enter the appropriate configuration options when prompted.
 
     ```text
         Sock Path
         > /var/run/docker.sock
+    ```
+
+6. Click `Enter` to confirm setting the Target.
+
+    ```text
+        Target set successfully
+     ```
+
+## Docker (Remote)
+
+Daytona allows you to set a remote Docker Target to use for deploying and managing Workspaces. The remote Docker Target enables you to deploy Workspaces on a remote machine using Docker.
+
+1. Run the following command to set a Target:
+
+    ```shell
+    daytona target set
+    ```
+
+2. Select `docker-provider` to use the Docker Provider.
+
+    ```text
+        Choose a Provider
+        1 item
+        ===
+        docker-provider
+        v0.0.0
+    ```
+
+3. Select `New Target` to set a remote Docker target.
+
+    ```text
+        Choose a Target
+        1 item
+        ===
+        + New Target
+    ```
+
+4. Enter a name for your Target.
+5. Enter the appropriate configuration options when prompted.
+
+    ```text
+        Remote Password
+        >
+
+        Remote Port
+        >
+
+        Remote User
+        Note: non-root user required
+        >
+
+        Sock Path
+        > /var/run/docker.sock
+
+        Workspace Data Dir       
+        The directory on the remote host where the workspace data will be stored
+        > /tmp/daytona-data
+
+        Remote Private Key Path
+        daytona_config
+        known_hosts
+        Custom path
+        None
     ```
 
 6. Click `Enter` to confirm setting the Target.

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -31,15 +31,21 @@ Daytona allows you to set a Target to use when managing Workspaces.
 
     ```text
         Choose a provider
-        1 item
+        4 items
         ===
+        aws-provider
+        v0.0.0
+        digitalocean-provider
+        v0.0.0
+        fly-provider
+        v0.0.0
         docker-provider
         v0.0.0
     ```
 
 3. Select `New Target`.
 4. Enter a name for your Target.
-5. Enter the appropriate configuration options when prompted.
+5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Provider. The following example shows setting a remote Docker Target.
 
     ```text
         Remote Password
@@ -126,3 +132,198 @@ Daytona allows you to delete Targets, helping you manage and remove those that a
     ```text
         Target MyTarget removed successfully
     ```
+
+## Docker
+
+Daytona allows you to set a Docker Target to use for deploying and managing Workspaces. The Docker Target enables you to deploy Workspaces on your local or remote machine using Docker.
+
+1. Run the following command to set a Target:
+
+    ```shell
+    daytona target set
+    ```
+
+2. Select `docker-provider` to use the Docker Provider.
+
+    ```text
+        Choose a provider
+        1 item
+        ===
+        docker-provider
+        v0.0.0
+    ```
+
+3. Select `local` to set a local Docker target, or `New Target` to set a remote Docker target.
+
+    - A local machine uses your local installation of Docker to deploy Workspaces and requires configuring the `Sock Path` to the Docker socket.
+
+    - A remote machine uses a remote installation of Docker to deploy Workspaces and requires configuring the remote `password`, `port`, `user`, `sock path`, `Workspace data directory`, and `private key path`.
+
+4. Enter a name for your Target.
+5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Provider. The following example shows setting a local Docker Target.
+
+    ```text
+        Sock Path
+        > /var/run/docker.sock
+    ```
+
+6. Click `Enter` to confirm setting the Target.
+
+    ```text
+        Target set successfully
+     ```
+
+## AWS
+
+Daytona allows you to set an AWS Target to use for deploying and managing Workspaces.
+
+1. Run the following command to set a Target:
+
+    ```shell
+    daytona target set
+    ```
+
+2. Select `aws-provider` to use the AWS Provider.
+
+    ```text
+        Choose a provider
+        1 item
+        ===
+        aws-provider
+        v0.0.0
+    ```
+
+3. Select `New Target`.
+4. Enter a name for your Target.
+5. Enter the appropriate configuration options when prompted.
+
+    ```text
+    The type of instance to launch. Default is t2.micro. 
+    List of available instance types https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/i
+    >
+
+    Region
+    The geographic area where AWS resourced are hosted. Default is us-east-1.
+    > 
+
+    Secret Access Key
+    If empty, it will be fetched from the AWS_SECRET_ACCESS_KEY environment variable.
+    >
+
+    Volume Size
+    The size of the instance volume, in GB. Default is 20 GB. 
+    It is recommended that the disk size should be more than 20 GB.
+    >
+
+    Volume Type
+    The type of volume. Default is gp3. 
+    List of available volume types https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html 
+    >
+    ```
+
+6. Click `Enter` to confirm setting the Target.
+
+    ```text
+        Target set successfully
+     ```
+
+## DigitalOcean
+
+Daytona allows you to set a DigitalOcean Target to use for deploying and managing Workspaces.
+
+1. Run the following command to set a Target:
+
+    ```shell
+    daytona target set
+    ```
+
+2. Select `digitalocean-provider` to use the DigitalOcean Provider.
+
+    ```text
+        Choose a provider
+        1 item
+        ===
+        digitalocean-provider
+        v0.0.0
+    ```
+
+3. Select `New Target`.
+4. Enter a name for your Target.
+5. Enter the appropriate configuration options when prompted.
+
+    ```text
+    Auth Token
+    If empty, token will be fetched from the DIGITALOCEAN_ACCESS_TOKEN environment variable.
+    >
+
+    Disk Size
+    > 
+
+    Image
+    >
+
+    Region
+    >
+
+    Size
+    >
+    ```
+
+6. Click `Enter` to confirm setting the Target.
+
+    ```text
+        Target set successfully
+     ```
+
+## Fly
+
+Daytona allows you to set a DigitalOcean Target to use for deploying and managing Workspaces.
+
+1. Run the following command to set a Target:
+
+    ```shell
+    daytona target set
+    ```
+
+2. Select `fly-provider` to use the Fly Provider.
+
+    ```text
+        Choose a provider
+        1 item
+        ===
+        fly-provider
+        v0.0.0
+    ```
+
+3. Select `New Target`.
+4. Enter a name for your Target.
+5. Enter the appropriate configuration options when prompted.
+
+    ```text
+    Auth Token
+    If empty, token will be fetched from the FLY_ACCESS_TOKEN environment variable. 
+    >
+
+    Disk Size
+    The size of the disk in GB.
+    > 
+
+    Org Slug
+    The organization name to create the fly machine in.
+    >
+
+    Region
+    The region where the fly machine resides. If not specified, near region will be used.
+    >
+
+    Size
+    The size of the fly machine. Default is shared-cpu-4x. 
+    List of available sizes https://fly.io/docs/about/pricing/#started-fly-machines
+    >
+    ```
+
+6. Click `Enter` to confirm setting the Target.
+
+    ```text
+        Target set successfully
+     ```

--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -17,7 +17,7 @@ Creating your own Workspace in Daytona is a straightforward process that ensures
 
 **Prerequisite**
 
-- **At least [one Target configured](/configuration/providers#managing-targets)**.
+- **At least [one Target configured](/configuration/targets)**.
 
   Targets are essential for deploying your Workspaces, so make sure you have configured at least one.
 


### PR DESCRIPTION
Fixes https://github.com/daytonaio/docs/issues/122
Fixes https://github.com/daytonaio/docs/issues/127

Since there are now multiple providers available, the page can be restructured to:

`/configuration/providers#docker`
`/configuration/providers#aws`
`/configuration/providers#digitalocean`
`/configuration/providers#flyio`

Currently, these are available under `/configuration/providers#officially-supported-providers`.