### PR TITLE
docs: fix cli reference hyperlink

### DIFF
--- a/tools/update-cli-reference.js
+++ b/tools/update-cli-reference.js
@@ -22,7 +22,7 @@ You can use the \`daytona\` tool for the following operations:
 
 *   Managing the lifecycle of the Daytona Server.
 *   Managing [Workspaces](../usage/workspaces), [Git Providers](../configuration/git-providers), [Providers](../configuration/providers), and other Daytona components.
-*   Configuring the [Daytona Server](./server) interactively.
+*   Configuring the [Daytona Server](../configuration/server) interactively.
 
 This reference lists all commands supported by the \`daytona\` command-line tool complete with a description of their behaviour, and any supported flags.
 You can access this documentation on a per-command basis by appending the \`--help\`/\`-h\` flag when invoking \`daytona\`.


### PR DESCRIPTION
The current tool for updating the CLI reference has a hyperlink leading to an non-existing page. This pull request updates the hyperlink to lead to the correct page.