### PR TITLE
docs: consistent style indentation formatting

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -8,6 +8,7 @@
     "no-duplicate-heading": false,
     "emphasis-style": {
       "style": "underscore"
-    }
+    },
+    "ol-prefix": false
   }
 }

--- a/src/content/docs/about/getting-started.mdx
+++ b/src/content/docs/about/getting-started.mdx
@@ -135,27 +135,27 @@ By default, a Docker Provider is configured with `localhost` as the Target.
 
 1. Run the following command to install a Provider:
 
-    ```shell
-    daytona provider install
-    ```
+  ```shell
+  daytona provider install
+  ```
 
 2. Select the Docker Provider you want to install from the list.
 
-    ```text
-        Choose a provider to install
-        1 item
-        ===
-        docker-provider
-        v0.0.0
-    ```
+  ```text
+  Choose a provider to install
+  1 item
+  ===
+  docker-provider
+  v0.0.0
+  ```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying development environments.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying development environments.
 
-    ```text
-        Provider docker-provider has been successfully installed
-    ```
+```text
+Provider docker-provider has been successfully installed
+```
 
-    If this configuration meets your requirements, you can proceed with [setting a Target](#setting-a-target).
+If this configuration meets your requirements, you can proceed with [setting a Target](#setting-a-target).
 
 You can install additional Providers to extend Daytona's capabilities and support a wide range of container management platforms and cloud hosting services.
 

--- a/src/content/docs/configuration/git-providers.mdx
+++ b/src/content/docs/configuration/git-providers.mdx
@@ -16,82 +16,80 @@ By adding a Git Provider, your credentials are securely embedded into your Works
 
 1. Run the following command to add a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to select the Git Provider you want to add.
+Upon running this command, Daytona will prompt you to select the Git Provider you want to add.
 
-    ```text
-        Choose a Git provider
-        GitHub
-        GitLab
-        Bitbucket
-        Other
-    ```
+```text
+Choose a Git provider
+GitHub
+GitLab
+Bitbucket
+Other
+```
 
 2. Select the Git Provider you want to configure from the list:
 
-    - __[GitHub](#github)__
+- __[GitHub](#github)__
 
-        Select if you are hosting repositories on GitHub.
+    Select if you are hosting repositories on GitHub.
 
-    - __[GitLab](#gitlab)__
+- __[GitLab](#gitlab)__
 
-        Select if you are hosting repositories on GitLab.
+    Select if you are hosting repositories on GitLab.
 
-    - __[Bitbucket](#bitbucket)__
+- __[Bitbucket](#bitbucket)__
 
-        Select if you are hosting repositories on Atlassian's Bitbucket Cloud platform.
+    Select if you are hosting repositories on Atlassian's Bitbucket Cloud platform.
 
-    - __Other__
+- __[GitHub Enterprise Server](#github-enterprise-server)__
 
-        - __[GitHub Enterprise Server](#github-enterprise-server)__
+    Select if you are hosting repositories on GitHub Enterprise Server.
 
-            Select if you are hosting repositories on GitHub Enterprise Server.
+- __[GitLab Self-Managed](#gitlab-self-managed)__
 
-        - __[GitLab Self-Managed](#gitlab-self-managed)__
+    Select if you are hosting repositories on GitLab's self-hosted platform.
 
-            Select if you are hosting repositories on GitLab's self-hosted platform.
+    Self-hosted GitLab Community Edition (CE) installations, GitLab Self-Managed, and GitLab Dedicated platforms are supported.
 
-            Self-hosted GitLab Community Edition (CE) installations, GitLab Self-Managed, and GitLab Dedicated platforms are supported.
+- __[Bitbucket Server](#bitbucket-server)__
 
-        - __[Bitbucket Server](#bitbucket-server)__
+    Select if you are hosting repositories on Bitbucket Server.
 
-            Select if you are hosting repositories on Bitbucket Server.
+- __[Codeberg](#codeberg)__
 
-        - __[Codeberg](#codeberg)__
+    Select if you are hosting repositories on Codeberg.
 
-            Select if you are hosting repositories on Codeberg.
+- __[Gitea](#gitea)__
 
-        - __[Gitea](#gitea)__
+    Select if you are hosting repositories on Gitea.
 
-            Select if you are hosting repositories on Gitea.
+- __[Gitness](#gitness)__
 
-        - __[Gitness](#gitness)__
+    Select if you are hosting repositories on Gitness.
 
-            Select if you are hosting repositories on Gitness.
+- __[Azure DevOps](#azure-devops)__
 
-        - __[Azure DevOps](#azure-devops)__
+    Select if you are hosting repositories on Azure DevOps.
 
-            Select if you are hosting repositories on Azure DevOps.
+- __[AWS CodeCommit](#aws-codecommit)__
 
-        - __[AWS CodeCommit](#aws-codecommit)__
-
-            Select if you are hosting repositories on AWS CodeCommit.
+    Select if you are hosting repositories on AWS CodeCommit.
 
 3. Enter your Git Provider credentials for Daytona to authenticate and enable secure access to your repositories.
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Some Git Providers require additional information such as your _username_ or the _URL_ of your self-managed API instance to complete the configuration.
+Some Git Providers require additional information such as your _username_ or the _URL_ of your self-managed API instance to complete the configuration.
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## List Connected Git Providers
 
@@ -99,16 +97,16 @@ Daytona allows you to keep track of your Git Providers by listing all previously
 
 1. Run the following command to list currently connected Git Providers:
 
-    ```shell
-    daytona git-providers list
-    ```
+```shell
+daytona git-providers list
+```
 
-    Upon running this command, Daytona will display a list of your connected Git Providers.
+Upon running this command, Daytona will display a list of your connected Git Providers.
 
-    ```text
-        GitHub (username)
-        GitLab (username)
-    ```
+```text
+GitHub (username)
+GitLab (username)
+```
 
 ## Delete a Git Provider
 
@@ -116,23 +114,23 @@ Daytona allows you to delete Git Providers, helping you manage and delete those 
 
 1. Run the following command to delete a Git Provider:
 
-    ```shell
-    daytona git-providers delete
-    ```
+```shell
+daytona git-providers delete
+```
 
-    Upon running this command, Daytona will display a list of existing Git Providers you can delete.
+Upon running this command, Daytona will display a list of existing Git Providers you can delete.
 
-    ```text
-        Choose a Git provider
-        GitHub
-        GitLab
-    ```
+```text
+Choose a Git provider
+GitHub
+GitLab
+```
 
 2. Select the Git Provider you want to delete.
 
-    ```text
-        Git provider has been removed
-    ```
+```text
+Git provider has been removed
+```
 
 ## GitHub
 
@@ -140,35 +138,33 @@ Daytona allows you to connect your GitHub account and access your repositories d
 
 1. Run the following command to add GitHub as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `GitHub` from the list.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `GitHub` from the list.
 
-    ```text
-        Choose a Git provider
-        > GitHub
-    ```
+```text
+Choose a Git provider
+> GitHub
+```
 
-    After selecting GitHub as your Git Provider, you will be prompted to enter a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit GitHub's [Creating a personal access token (classic)][gh-token] documentation.
+After selecting GitHub as your Git Provider, you will be prompted to enter a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit GitHub's [Creating a personal access token (classic)][gh-token] documentation.
 
 2. Enter your Personal Access Token for Daytona to authenticate and enable secure access to your GitHub repositories.
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## GitLab
 
@@ -176,35 +172,33 @@ Daytona allows you to connect your GitLab account and access your repositories d
 
 1. Run the following command to add GitLab as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `GitLab` from the list.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `GitLab` from the list.
 
-    ```text
-        Choose a Git provider
-        > GitLab
-    ```
+```text
+Choose a Git provider
+> GitLab
+```
 
-    After selecting GitLab as your Git Provider, you will be prompted to enter a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit GitLab's [Create a personal access token][gl-token] documentation.
+After selecting GitLab as your Git Provider, you will be prompted to enter a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit GitLab's [Create a personal access token][gl-token] documentation.
 
 2. Enter your Personal Access Token for Daytona to authenticate and enable secure access to your GitLab repositories.
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## Bitbucket
 
@@ -212,40 +206,38 @@ Daytona allows you to connect your Bitbucket account and access your repositorie
 
 1. Run the following command to add Bitbucket as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Bitbucket` from the list.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Bitbucket` from the list.
 
-    ```text
-        Choose a Git provider
-        > Bitbucket
-    ```
+```text
+Choose a Git provider
+> Bitbucket
+```
 
-    After selecting Bitbucket as your Git Provider, you will be prompted to enter a Username (your Atlassian username) and a Personal Access Token (App Password).
-    <br />
-    For more information on creating a Personal Access Token, visit Bitbucket's [Create an App password][bit-token] documentation.
+After selecting Bitbucket as your Git Provider, you will be prompted to enter a Username (your Atlassian username) and a Personal Access Token (App Password).
 
-    <br />
+For more information on creating a Personal Access Token, visit Bitbucket's [Create an App password][bit-token] documentation.
 
 2. Enter your Username and Personal Access Token for Daytona to authenticate and enable secure access to your Bitbucket repositories.
 
-    ```text
-        Username
-        >
-    ```
+```text
+Username
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## GitHub Enterprise Server
 
@@ -253,46 +245,44 @@ Daytona allows you to connect your GitHub Enterprise Server account and access y
 
 1. Run the following command to add GitHub Enterprise Server as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `GitHub Enterprise Server`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `GitHub Enterprise Server`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > GitHub Enterprise Server
-    ```
+```text
+Choose a Git provider
+> GitHub Enterprise Server
+```
 
-    After selecting GitHub Enterprise Server as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for your GitHub Enterprise Server instance's API) and a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit GitHub's [Creating a personal access token (classic)][gh-enterprise-token] documentation.
+After selecting GitHub Enterprise Server as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for your GitHub Enterprise Server instance's API) and a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit GitHub's [Creating a personal access token (classic)][gh-enterprise-token] documentation.
 
 2. Enter your Self-Managed API URL and Personal Access Token for Daytona to authenticate and enable secure access to your Github Enterprise repositories.
 
-    ```text
-        Self-managed API URL
-        For example: https://github-host
-        >
-    ```
+```text
+Self-managed API URL
+For example: https://github-host
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## GitLab Self-Managed
 
@@ -300,46 +290,44 @@ Daytona allows you to connect your GitLab Self-Managed account and access your r
 
 1. Run the following command to add GitLab Self-Managed as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `GitLab Self-managed`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `GitLab Self-managed`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > GitLab Self-managed
-    ```
+```text
+Choose a Git provider
+> GitLab Self-managed
+```
 
-    After selecting GitLab Self-Managed as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the self-hosted GitLab API) and a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit GitLab's [Create a personal access token][gl-token] documentation.
+After selecting GitLab Self-Managed as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the self-hosted GitLab API) and a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit GitLab's [Create a personal access token][gl-token] documentation.
 
 2. Enter your Self-Managed API URL and Personal Access Token for Daytona to authenticate and enable secure access to your GitLab Self-Managed repositories.
 
-    ```text
-        Self-managed API URL
-        For example: http://gitlab-host/api/v4/ 
-        >
-    ```
+```text
+Self-managed API URL
+For example: http://gitlab-host/api/v4/ 
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## Bitbucket Server
 
@@ -347,51 +335,49 @@ Daytona allows you to connect your Bitbucket Server account and access your repo
 
 1. Run the following command to add Bitbucket Server as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Bitbucket Server`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Bitbucket Server`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > Bitbucket Server
-    ```
+```text
+Choose a Git provider
+> Bitbucket Server
+```
 
-    After selecting Bitbucket Server as your Git Provider, you will be prompted to enter a Username (your Atlassian username), Self-managed API URL (the base URL for your Bitbucket Server instance's API), and a Personal Access Token (App Password).
-    <br />
-    For more information on creating a Personal Access Token, visit Bitbucket's [Create an App password][bit-token] documentation.
+After selecting Bitbucket Server as your Git Provider, you will be prompted to enter a Username (your Atlassian username), Self-managed API URL (the base URL for your Bitbucket Server instance's API), and a Personal Access Token (App Password).
 
-    <br />
+For more information on creating a Personal Access Token, visit Bitbucket's [Create an App password][bit-token] documentation.
 
 2. Enter your Username, Self-managed API URL, and Personal Access Token for Daytona to authenticate and enable secure access to your Bitbucket Server repositories.
 
-    ```text
-        Username
-        >
-    ```
+```text
+Username
+>
+```
 
-    ```text
-        Self-managed API URL
-        For example: https://bitbucket.host.com/rest
-        >
-    ```
+```text
+Self-managed API URL
+For example: https://bitbucket.host.com/rest
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## Codeberg
 
@@ -399,40 +385,38 @@ Daytona allows you to connect your Codeberg account and access your repositories
 
 1. Run the following command to add Codeberg as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Codeberg`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Codeberg`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > Codeberg
-    ```
+```text
+Choose a Git provider
+> Codeberg
+```
 
-    After selecting Codeberg as your Git Provider, you will be prompted to enter a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit Codeberg's [Generating an Access Token][codeberg-token] documentation.
+After selecting Codeberg as your Git Provider, you will be prompted to enter a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit Codeberg's [Generating an Access Token][codeberg-token] documentation.
 
 2. Enter your Personal Access Token for Daytona to authenticate and enable secure access to your Codeberg repositories.
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## Gitea
 
@@ -440,46 +424,44 @@ Daytona allows you to connect your Gitea account and access your repositories di
 
 1. Run the following command to add Gitea as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Gitea`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Gitea`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > Gitea
-    ```
+```text
+Choose a Git provider
+> Gitea
+```
 
-    After selecting Gitea as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the Gitea installation's API) and a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit Gitea's [Generating and listing API tokens][gitea-token] documentation.
+After selecting Gitea as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the Gitea installation's API) and a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit Gitea's [Generating and listing API tokens][gitea-token] documentation.
 
 2. Enter your Self-Managed API URL and Personal Access Token for Daytona to authenticate and enable secure access to your Gitea repositories.
 
-    ```text
-        Self-managed API URL
-        For example: http://gitea-host
-        >
-    ```
+```text
+Self-managed API URL
+For example: http://gitea-host
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## Gitness
 
@@ -487,46 +469,44 @@ Daytona allows you to connect your Gitness account and access your repositories 
 
 1. Run the following command to add Gitness as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Gitness`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Gitness`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > Gitness
-    ```
+```text
+Choose a Git provider
+> Gitness
+```
 
-    After selecting Gitness as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the Gitness installation's API) and a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit Gitness' [Generate user token][gitness-token] documentation.
+After selecting Gitness as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the Gitness installation's API) and a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit Gitness' [Generate user token][gitness-token] documentation.
 
 2. Enter your Self-Managed API URL and Personal Access Token for Daytona to authenticate and enable secure access to your Gitness repositories.
 
-    ```text
-        Self-managed API URL
-        For example: http://gitness-host/api/v1/
-        >
-    ```
+```text
+Self-managed API URL
+For example: http://gitness-host/api/v1/
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## Azure DevOps
 
@@ -534,46 +514,44 @@ Daytona allows you to connect your Azure DevOps account and access your reposito
 
 1. Run the following command to add Azure DevOps as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Azure DevOps`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `Azure DevOps`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > Azure DevOps
-    ```
+```text
+Choose a Git provider
+> Azure DevOps
+```
 
-    After selecting Azure DevOps as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the Azure DevOps installation's API) and a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit Azure DevOps' [Create a Personal Access Token][azuredevops-token] documentation.
+After selecting Azure DevOps as your Git Provider, you will be prompted to enter a Self-Managed API URL (the base URL for the Azure DevOps installation's API) and a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit Azure DevOps' [Create a Personal Access Token][azuredevops-token] documentation.
 
 2. Enter your Self-Managed API URL and Personal Access Token for Daytona to authenticate and enable secure access to your Azure DevOps repositories.
 
-    ```text
-        Self-managed API URL
-        For example: https://dev.azure.com/organization
-        >
-    ```
+```text
+Self-managed API URL
+For example: https://dev.azure.com/organization
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 ## AWS CodeCommit
 
@@ -581,59 +559,55 @@ Daytona allows you to connect your AWS CodeCommit account and access your reposi
 
 1. Run the following command to add AWS CodeCommit as a Git Provider:
 
-    ```shell
-    daytona git-providers add
-    ```
+```shell
+daytona git-providers add
+```
 
-    Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `AWS CodeCommit`.
+Upon running this command, Daytona will prompt you to choose a Git Provider you want to add. Select `Other` from the list, and then select `AWS CodeCommit`.
 
-    ```text
-        Choose a Git provider
-        > Other
-    ```
+```text
+Choose a Git provider
+> Other
+```
 
-    ```text
-        Choose a Git provider
-        > AWS CodeCommit
-    ```
+```text
+Choose a Git provider
+> AWS CodeCommit
+```
 
-    After selecting AWS CodeCommit as your Git Provider, you will be prompted to enter a Username, a Self-Managed API URL (the base URL for the AWS CodeCommit installation's API) and a Personal Access Token.
-    <br />
-    For more information on creating a Personal Access Token, visit AWS CodeCommit's [Authentication and access control][awscodecommit-token] documentation.
+After selecting AWS CodeCommit as your Git Provider, you will be prompted to enter a Username, a Self-Managed API URL (the base URL for the AWS CodeCommit installation's API) and a Personal Access Token.
 
-    <br />
+For more information on creating a Personal Access Token, visit AWS CodeCommit's [Authentication and access control][awscodecommit-token] documentation.
 
-    <Aside type="note">
+<Aside type="note">
+The user must have configured AWS Credentials: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, and have `iam:GetUser` read permission.
+</Aside>
 
-    The user must have configured AWS Credentials: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, and have `iam:GetUser` read permission.
-
-    </Aside>
-
-    <br />
+<br />
 
 2. Enter your Username, Self-Managed API URL, and Personal Access Token for Daytona to authenticate and enable secure access to your AWS CodeCommit repositories.
 
-    ```text
-        Username
-        >
-    ```
+```text
+Username
+>
+```
 
-    ```text
-        Self-managed API URL
-        For example: https://ap-south-1.console.aws.amazon.com
-        >
-    ```
+```text
+Self-managed API URL
+For example: https://ap-south-1.console.aws.amazon.com
+>
+```
 
-    ```text
-        Personal access token
-        >
-    ```
+```text
+Personal access token
+>
+```
 
-    Upon successful authentication, Daytona will display the following message:
+Upon successful authentication, Daytona will display the following message:
 
-    ```text
-        Git provider has been registered
-    ```
+```text
+Git provider has been registered
+```
 
 [gh-token]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
 [gh-enterprise-token]: https://docs.github.com/en/enterprise-server@3.13/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -19,33 +19,33 @@ Daytona allows you to install a Provider to interface with the Daytona Server. O
 
 1. Run the following command to install a Provider:
 
-    ```shell
-    daytona provider install
-    ```
+```shell
+daytona provider install
+```
 
 2. Select the Provider you want to install from the list or select a specific version.
 
-    ```text
-        Choose a provider to install
-        5 items
-        ===
-        fly-provider
-        v0.0.0
-        aws-provider
-        v0.0.0
-        docker-provider
-        v0.0.0
-        digitalocean-provider
-        v0.0.0
+```text
+Choose a provider to install
+5 items
+===
+fly-provider
+v0.0.0
+aws-provider
+v0.0.0
+docker-provider
+v0.0.0
+digitalocean-provider
+v0.0.0
 
-        Select a specific version
-    ```
+Select a specific version
+```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces. You can now create a [Target](/configuration/targets) to use with the created Provider.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces. You can now create a [Target](/configuration/targets) to use with the created Provider.
 
-    ```text
-        Provider docker-provider has been successfully installed
-    ```
+```text
+Provider docker-provider has been successfully installed
+```
 
 ## List Providers
 
@@ -53,17 +53,17 @@ Daytona allows you to list all installed Providers, providing you with an overvi
 
 1. Run the following command to list all installed Providers:
 
-    ```shell
-    daytona provider list
-    ```
+```shell
+daytona provider list
+```
 
-    Upon running this command, Daytona will display a list of your installed Providers and their respective versions.
+Upon running this command, Daytona will display a list of your installed Providers and their respective versions.
 
-    ```text
-        Name                                Version               
-        ───────────────────────────────────────────
-        docker-provider                     v.0.0.0
-   ```
+```text
+Name                                Version               
+───────────────────────────────────────────
+docker-provider                     v.0.0.0
+```
 
 ## Update a Provider
 
@@ -71,23 +71,23 @@ Daytona allows you to update an existing Provider, enabling you to apply the lat
 
 1. Run the following command to update a Provider:
 
-    ```shell
-    daytona provider update
-    ```
+```shell
+daytona provider update
+```
 
 2. Select the Provider you want to update from the list.
 
-    ```text
-        Choose a provider to update
-        1 item
-        ===
-        docker-provider
-        v0.0.0
-    ```
+```text
+Choose a provider to update
+1 item
+===
+docker-provider
+v0.0.0
+```
 
-    ```text
-        Provider docker-provider has been successfully updated
-    ```
+```text
+Provider docker-provider has been successfully updated
+```
 
 ## Uninstall a Provider
 
@@ -95,23 +95,23 @@ Daytona allows you to uninstall an existing Provider, helping you manage your Pr
 
 1. Run the following command to uninstall a Provider:
 
-    ```shell
-    daytona provider uninstall
-    ```
+```shell
+daytona provider uninstall
+```
 
 2. Select the Provider you want to uninstall from the list.
 
-    ```text
-        Choose a provider to uninstall
-        1 item
-        ===
-        docker-provider
-        v0.0.0
-    ```
+```text
+Choose a provider to uninstall
+1 item
+===
+docker-provider
+v0.0.0
+```
 
-    ```text
-        Provider docker-provider has been successfully uninstalled
-    ```
+```text
+Provider docker-provider has been successfully uninstalled
+```
 
 ## Docker
 
@@ -119,28 +119,28 @@ The Docker Provider allows Daytona to create Workspace projects as Docker contai
 
 1. Run the following command to install a Docker Provider:
 
-    ```shell
-    daytona provider install
-    ```
+```shell
+daytona provider install
+```
 
 2. Select `docker-provider` to install Docker as your Provider.
 
-    ```text
-        Choose a provider to install
-        ===
-        > docker-provider
-          v0.0.0
-    ```
+```text
+Choose a provider to install
+===
+> docker-provider
+    v0.0.0
+```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
-    ```text
-        ⡿  Installing...
-    ```
+```text
+⡿  Installing...
+```
 
-    ```text
-        Provider docker-provider has been successfully installed
-    ```
+```text
+Provider docker-provider has been successfully installed
+```
 
 <DocumentList>
 <DocumentListItem
@@ -159,28 +159,28 @@ To use the AWS Provider, ensure that your AWS programmatic access user has the `
 
 1. Run the following command to install an AWS Provider:
 
-    ```shell
-    daytona provider install
-    ```
+```shell
+daytona provider install
+```
 
 2. Select `aws-provider` to install AWS as your Provider.
 
-    ```text
-        Choose a provider to install
-        ===
-        > aws-provider
-          v0.0.0
-    ```
+```text
+Choose a provider to install
+===
+> aws-provider
+    v0.0.0
+```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
-    ```text
-        ⡿  Installing...
-    ```
+```text
+⡿  Installing...
+```
 
-    ```text
-        Provider aws-provider has been successfully installed
-    ```
+```text
+Provider aws-provider has been successfully installed
+```
 
 <DocumentList>
 <DocumentListItem
@@ -197,28 +197,28 @@ The DigitalOcean Provider allows Daytona to create Workspace projects on Digital
 
 1. Run the following command to install a DigitalOcean Provider:
 
-    ```shell
-    daytona provider install
-    ```
+```shell
+daytona provider install
+```
 
 2. Select `digitalocean-provider` to install DigitalOcean as your Provider.
 
-    ```text
-        Choose a provider to install
-        ===
-        > digitalocean-provider
-          v0.0.0
-    ```
+```text
+Choose a provider to install
+===
+> digitalocean-provider
+    v0.0.0
+```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
-    ```text
-        ⡿  Installing...
-    ```
+```text
+⡿  Installing...
+```
 
-    ```text
-        Provider digitalocean-provider has been successfully installed
-    ```
+```text
+Provider digitalocean-provider has been successfully installed
+```
 
 <DocumentList>
 <DocumentListItem
@@ -235,28 +235,28 @@ The Fly Provider allows Daytona to create Workspace projects on Fly VMs, known a
 
 1. Run the following command to install a Fly Provider:
 
-    ```shell
-    daytona provider install
-    ```
+```shell
+daytona provider install
+```
 
 2. Select `fly-provider` to install Fly as your Provider.
 
-    ```text
-        Choose a provider to install
-        ===
-        > fly-provider
-          v0.0.0
-    ```
+```text
+Choose a provider to install
+===
+> fly-provider
+    v0.0.0
+```
 
-    Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces.
 
-    ```text
-        ⡿  Installing...
-    ```
+```text
+⡿  Installing...
+```
 
-    ```text
-        Provider fly-provider has been successfully installed
-    ```
+```text
+Provider fly-provider has been successfully installed
+```
 
 <DocumentList>
 <DocumentListItem

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -23,60 +23,60 @@ Daytona allows you to set a Target to use when managing Workspaces.
 
 1. Run the following command to set a Target:
 
-    ```shell
-    daytona target set
-    ```
+```shell
+daytona target set
+```
 
 2. Select the appropriate Provider for the environment you want to deploy to.
 
-    ```text
-        Choose a provider
-        4 items
-        ===
-        aws-provider
-        v0.0.0
-        digitalocean-provider
-        v0.0.0
-        fly-provider
-        v0.0.0
-        docker-provider
-        v0.0.0
-    ```
+```text
+Choose a provider
+4 items
+===
+aws-provider
+v0.0.0
+digitalocean-provider
+v0.0.0
+fly-provider
+v0.0.0
+docker-provider
+v0.0.0
+```
 
 3. Select `New Target`.
 4. Enter a name for your Target.
 5. Enter the appropriate configuration options when prompted. The configuration options vary based on the selected Provider. The following example shows setting a remote Docker Target.
 
-    ```text
-        Remote Password
-        >
+```text
+Remote Password
+>
 
-        Remote Port
-        >
+Remote Port
+>
 
-        Remote User
-        Note: non-root user required
-        >
+Remote User
+Note: non-root user required
+>
 
-        Sock Path
-        > /var/run/docker.sock
+Sock Path
+> /var/run/docker.sock
 
-        Workspace Data Dir       
-        The directory on the remote host where the workspace data will be stored
-        > /tmp/daytona-data
+Workspace Data Dir       
+The directory on the remote host where the workspace data will be stored
+> /tmp/daytona-data
 
-        Remote Private Key Path
-        daytona_config
-        known_hosts
-        Custom path
-        None
-    ```
+Remote Private Key Path
+daytona_config
+known_hosts
+Custom path
+None
+```
 
 6. Click `Enter` to confirm setting the Target.
 
-    ```text
-        Target set successfully
-     ```
+```text
+Target set successfully
+```
 
 ## List Targets
 
@@ -84,19 +84,19 @@ Daytona allows you to keep track of your Targets by listing all previously creat
 
 1. Run the following command to list currently set Targets:
 
-   ```shell
-   daytona target list
-   ```
+```shell
+daytona target list
+```
 
-   Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the Provider it is connected to, and its configured options.
+Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the Provider it is connected to, and its configured options.
 
-   ```text
-    Target      Provider            Options
-    ───────────────────────────────────────────────────────────────────────
-    MyTarget    docker-provider     {
-                                        "Sock Path": "/var/run/docker.sock"
-                                    }
-   ```
+```text
+Target      Provider            Options
+───────────────────────────────────────────────────────────────────────
+MyTarget    docker-provider     {
+                                    "Sock Path": "/var/run/docker.sock"
+                                }
+```
 
 ## Delete a Target
 
@@ -104,34 +104,34 @@ Daytona allows you to delete Targets, helping you manage and remove those that a
 
 1. Run the following command:
 
-    ```shell
-    daytona target delete
-    ```
+```shell
+daytona target delete
+```
 
-    Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the unique identifier of the Workspace, and the repository it is connected to.
+Upon running this command, Daytona will display a list of your Targets with their details. You will be able to see the Target name, the unique identifier of the Workspace, and the repository it is connected to.
 
 2. Press `Enter` on the selected Target to delete it.
 
-    ```text
-        Choose a Target
-        1 item
-        ===
-        MyTarget          
-        docker-provider
-    ```
+```text
+Choose a Target
+1 item
+===
+MyTarget          
+docker-provider
+```
 
 3. Confirm the action.
 
-    ```text
-        Delete all workspaces within MyTarget?
-        You might not be able to easily remove these workspaces later.
-        
-        [Yes]     [No]
-    ```
+```text
+Delete all workspaces within MyTarget?
+You might not be able to easily remove these workspaces later.
 
-    ```text
-        Target MyTarget removed successfully
-    ```
+[Yes]     [No]
+```
+
+```text
+Target MyTarget removed successfully
+```
 
 ## Docker (Local)
 
@@ -139,43 +139,43 @@ Daytona allows you to set a local Docker Target to use for deploying and managin
 
 1. Run the following command to set a Target:
 
-    ```shell
-    daytona target set
-    ```
+```shell
+daytona target set
+```
 
 2. Select `docker-provider` to use the Docker Provider.
 
-    ```text
-        Choose a provider
-        1 item
-        ===
-        docker-provider
-        v0.0.0
-    ```
+```text
+Choose a provider
+1 item
+===
+docker-provider
+v0.0.0
+```
 
 3. Select `local` to set a local Docker Target.
 
-    ```text
-        Choose a Target
-        1 item
-        ===
-        local
-        docker-provider
-    ```
+```text
+Choose a Target
+1 item
+===
+local
+docker-provider
+```
 
 4. Enter a name for your Target.
 5. Enter the appropriate configuration options when prompted.
 
-    ```text
-        Sock Path
-        > /var/run/docker.sock
-    ```
+```text
+Sock Path
+> /var/run/docker.sock
+```
 
 6. Click `Enter` to confirm setting the Target.
 
-    ```text
-        Target set successfully
-     ```
+```text
+Target set successfully
+```
 
 ## Docker (Remote)
 
@@ -183,62 +183,62 @@ Daytona allows you to set a remote Docker Target to use for deploying and managi
 
 1. Run the following command to set a Target:
 
-    ```shell
-    daytona target set
-    ```
+```shell
+daytona target set
+```
 
 2. Select `docker-provider` to use the Docker Provider.
 
-    ```text
-        Choose a Provider
-        1 item
-        ===
-        docker-provider
-        v0.0.0
-    ```
+```text
+Choose a Provider
+1 item
+===
+docker-provider
+v0.0.0
+```
 
 3. Select `New Target` to set a remote Docker target.
 
-    ```text
-        Choose a Target
-        1 item
-        ===
-        + New Target
-    ```
+```text
+Choose a Target
+1 item
+===
++ New Target
+```
 
 4. Enter a name for your Target.
 5. Enter the appropriate configuration options when prompted.
 
-    ```text
-        Remote Password
-        >
+```text
+Remote Password
+>
 
-        Remote Port
-        >
+Remote Port
+>
 
-        Remote User
-        Note: non-root user required
-        >
+Remote User
+Note: non-root user required
+>
 
-        Sock Path
-        > /var/run/docker.sock
+Sock Path
+> /var/run/docker.sock
 
-        Workspace Data Dir       
-        The directory on the remote host where the workspace data will be stored
-        > /tmp/daytona-data
+Workspace Data Dir       
+The directory on the remote host where the workspace data will be stored
+> /tmp/daytona-data
 
-        Remote Private Key Path
-        daytona_config
-        known_hosts
-        Custom path
-        None
-    ```
+Remote Private Key Path
+daytona_config
+known_hosts
+Custom path
+None
+```
 
 6. Click `Enter` to confirm setting the Target.
 
-    ```text
-        Target set successfully
-     ```
+```text
+Target set successfully
+```
 
 ## AWS
 
@@ -246,56 +246,56 @@ Daytona allows you to set an AWS Target to use for deploying and managing Worksp
 
 1. Run the following command to set a Target:
 
-    ```shell
-    daytona target set
-    ```
+```shell
+daytona target set
+```
 
 2. Select `aws-provider` to use the AWS Provider.
 
-    ```text
-        Choose a provider
-        1 item
-        ===
-        aws-provider
-        v0.0.0
-    ```
+```text
+Choose a provider
+1 item
+===
+aws-provider
+v0.0.0
+```
 
 3. Select `New Target`.
 4. Enter a name for your Target.
 5. Enter the appropriate configuration options when prompted.
 
-    ```text
-    The type of instance to launch. Default is t2.micro. 
-    List of available instance types https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/i
-    >
+```text
+The type of instance to launch. Default is t2.micro. 
+List of available instance types https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/i
+>
 
-    Region
-    The geographic area where AWS resources are hosted. Default is us-east-1.
-    List of available regions https://docs.aws.amazon.com/general/latest/gr/rande.html
-    > 
+Region
+The geographic area where AWS resources are hosted. Default is us-east-1.
+List of available regions https://docs.aws.amazon.com/general/latest/gr/rande.html
+> 
 
-    Secret Access Key
-    Find this in the AWS Console under "My Security Credentials" (https://aws.amazon.com/premiumsupport/knowledge-center/manage-access-keys/).
-    Leave blank if you've set the AWS_SECRET_ACCESS_KEY environment variable, or enter your key here.
-    >
+Secret Access Key
+Find this in the AWS Console under "My Security Credentials" (https://aws.amazon.com/premiumsupport/knowledge-center/manage-access-keys/).
+Leave blank if you've set the AWS_SECRET_ACCESS_KEY environment variable, or enter your key here.
+>
 
-    Volume Size
-    The size of the instance volume, in GB. Default is 20 GB.
-    It is recommended that the disk size should be more than 20 GB.
-    List of volume size limits: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html
-    >
+Volume Size
+The size of the instance volume, in GB. Default is 20 GB.
+It is recommended that the disk size should be more than 20 GB.
+List of volume size limits: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html
+>
 
-    Volume Type
-    The type of volume. Default is gp3.
-    List of available volume types https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html
-    >
-    ```
+Volume Type
+The type of volume. Default is gp3.
+List of available volume types https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html
+>
+```
 
 6. Click `Enter` to confirm setting the Target.
 
-    ```text
-        Target set successfully
-     ```
+```text
+Target set successfully
+```
 
 ## DigitalOcean
 
@@ -303,47 +303,47 @@ Daytona allows you to set a DigitalOcean Target to use for deploying and managin
 
 1. Run the following command to set a Target:
 
-    ```shell
-    daytona target set
-    ```
+```shell
+daytona target set
+```
 
 2. Select `digitalocean-provider` to use the DigitalOcean Provider.
 
-    ```text
-        Choose a provider
-        1 item
-        ===
-        digitalocean-provider
-        v0.0.0
-    ```
+```text
+Choose a provider
+1 item
+===
+digitalocean-provider
+v0.0.0
+```
 
 3. Select `New Target`.
 4. Enter a name for your Target.
 5. Enter the appropriate configuration options when prompted.
 
-    ```text
-    Auth Token
-    If empty, token will be fetched from the DIGITALOCEAN_ACCESS_TOKEN environment variable.
-    >
+```text
+Auth Token
+If empty, token will be fetched from the DIGITALOCEAN_ACCESS_TOKEN environment variable.
+>
 
-    Disk Size
-    > 
+Disk Size
+> 
 
-    Image
-    >
+Image
+>
 
-    Region
-    >
+Region
+>
 
-    Size
-    >
-    ```
+Size
+>
+```
 
 6. Click `Enter` to confirm setting the Target.
 
-    ```text
-        Target set successfully
-     ```
+```text
+Target set successfully
+```
 
 ## Fly
 
@@ -351,49 +351,49 @@ Daytona allows you to set a DigitalOcean Target to use for deploying and managin
 
 1. Run the following command to set a Target:
 
-    ```shell
-    daytona target set
-    ```
+```shell
+daytona target set
+```
 
 2. Select `fly-provider` to use the Fly Provider.
 
-    ```text
-        Choose a provider
-        1 item
-        ===
-        fly-provider
-        v0.0.0
-    ```
+```text
+Choose a provider
+1 item
+===
+fly-provider
+v0.0.0
+```
 
 3. Select `New Target`.
 4. Enter a name for your Target.
 5. Enter the appropriate configuration options when prompted.
 
-    ```text
-    Auth Token
-    If empty, token will be fetched from the FLY_ACCESS_TOKEN environment variable. 
-    >
+```text
+Auth Token
+If empty, token will be fetched from the FLY_ACCESS_TOKEN environment variable. 
+>
 
-    Disk Size
-    The size of the disk in GB.
-    > 
+Disk Size
+The size of the disk in GB.
+> 
 
-    Org Slug
-    The organization name to create the fly machine in.
-    >
+Org Slug
+The organization name to create the fly machine in.
+>
 
-    Region
-    The region where the fly machine resides. If not specified, near region will be used.
-    >
+Region
+The region where the fly machine resides. If not specified, near region will be used.
+>
 
-    Size
-    The size of the fly machine. Default is shared-cpu-4x. 
-    List of available sizes https://fly.io/docs/about/pricing/#started-fly-machines
-    >
-    ```
+Size
+The size of the fly machine. Default is shared-cpu-4x. 
+List of available sizes https://fly.io/docs/about/pricing/#started-fly-machines
+>
+```
 
 6. Click `Enter` to confirm setting the Target.
 
-    ```text
-        Target set successfully
-     ```
+```text
+Target set successfully
+```

--- a/src/content/docs/installation/installation.mdx
+++ b/src/content/docs/installation/installation.mdx
@@ -60,8 +60,9 @@ curl -sf -L https://download.daytona.io/daytona/v0.27/daytona-linux-arm64 -o day
 ### Nix
 
 <Nix />
-#### Install Globally To permanently install Daytona on your system, you can add
-it to the relevant configuration.
+#### Install Globally
+
+To permanently install Daytona on your system, you can add it to the relevant configuration.
 
 - On NixOS systems, add `daytona-bin` as a system package in `/etc/nixos/configuration.nix`.
 - On other Linux systems, use [home-manager](https://github.com/nix-community/home-manager) and add `daytona-bin` as a local package.

--- a/src/content/docs/installation/method/homebrew.mdx
+++ b/src/content/docs/installation/method/homebrew.mdx
@@ -9,10 +9,10 @@ The package is available in a Homebrew Tap.
 
 1. Execute the following command to install Daytona:
 
-    ```shell
-    brew tap daytonaio/tap
-    brew install daytona
-    ```
+```shell
+brew tap daytonaio/tap
+brew install daytona
+```
 
 #### Uninstall Daytona
 
@@ -27,9 +27,9 @@ Ensure you have a backup of any Workspace data and relevant configuration before
 
 1. Execute the following command to uninstall Daytona:
 
-    ```shell
-    brew uninstall daytona
-    ```
+```shell
+brew uninstall daytona
+```
 
 #### Upgrading Daytona
 
@@ -37,7 +37,7 @@ You can upgrade Daytona using Homebrew.
 
 1. Execute the following commands to upgrade Daytona:
 
-    ```shell
-    brew update
-    brew upgrade daytona
-    ```
+```shell
+brew update
+brew upgrade daytona
+```

--- a/src/content/docs/installation/method/nix.mdx
+++ b/src/content/docs/installation/method/nix.mdx
@@ -12,6 +12,6 @@ You can use `nix-shell` to try Daytona before permanently installing it on your 
 
 1. Execute the following command to spawn a shell with the Daytona binary:
 
-    ```shell
-    nix-shell -p daytona-bin
-    ```
+```shell
+nix-shell -p daytona-bin
+```

--- a/src/content/docs/installation/method/script-powershell.mdx
+++ b/src/content/docs/installation/method/script-powershell.mdx
@@ -8,13 +8,13 @@ export const partial = true
 
 1. Run the following command in PowerShell:
 
-   ```powershell
-   $architecture = if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") { "amd64" } else { "arm64" }
-   md -Force "$Env:APPDATA\bin\daytona"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-   Invoke-WebRequest -URI "https://download.daytona.io/daytona/v0.27/daytona-windows-$architecture.exe" -OutFile "$Env:APPDATA\bin\daytona\daytona.exe";
-   $env:Path += ";" + $Env:APPDATA + "\bin\daytona"; [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
-   daytona serve;
-   ```
+```powershell
+$architecture = if ($env:PROCESSOR_ARCHITECTURE -eq "AMD64") { "amd64" } else { "arm64" }
+md -Force "$Env:APPDATA\bin\daytona"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
+Invoke-WebRequest -URI "https://download.daytona.io/daytona/v0.27/daytona-windows-$architecture.exe" -OutFile "$Env:APPDATA\bin\daytona\daytona.exe";
+$env:Path += ";" + $Env:APPDATA + "\bin\daytona"; [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
+daytona serve;
+```
 
 <Aside type="note">
 You can install Daytona by manually downloading the binary and placing it in your `PATH`.

--- a/src/content/docs/installation/method/script-unix.mdx
+++ b/src/content/docs/installation/method/script-unix.mdx
@@ -8,8 +8,8 @@ You can install Daytona using the official installation script.
 
 1. Run the following command in your shell:
 
-    ```shell
-    (curl -sf -L https://download.daytona.io/daytona/install.sh | sudo bash) && daytona server -y && daytona
-    ```
+```shell
+(curl -sf -L https://download.daytona.io/daytona/install.sh | sudo bash) && daytona server -y && daytona
+```
 
 2. Read and follow the instructions printed in your console.

--- a/src/content/docs/installation/method/uninstall-macos.mdx
+++ b/src/content/docs/installation/method/uninstall-macos.mdx
@@ -15,33 +15,33 @@ Ensure you have a backup of any Workspace data and relevant configuration before
 
 1. Run the following commands to purge local Daytona data and remove the binary:
 
-    ```shell
-    daytona purge
-    ```
+```shell
+daytona purge
+```
 
-    Run the following commands if the `daytona purge` command does not work, or if you want to manually purge local Daytona data and remove the binary:
+Run the following commands if the `daytona purge` command does not work, or if you want to manually purge local Daytona data and remove the binary:
 
-    ```shell
-    rm -rf ~/Library/Application\ Support/daytona
-    sudo rm $(whereis daytona | awk '{print $2}')
-    ```
+```shell
+rm -rf ~/Library/Application\ Support/daytona
+sudo rm $(whereis daytona | awk '{print $2}')
+```
 
-    Additionally, to fully remove all Daytona-related configurations and components, run the following command:
+Additionally, to fully remove all Daytona-related configurations and components, run the following command:
 
-    ```shell
-    rm -f ~/.ssh/daytona_config
-    ```
+```shell
+rm -f ~/.ssh/daytona_config
+```
 
-    Edit your `~/.ssh/config` file to remove the `Include daytona_config entry`. You can do this manually by running the following command:
+Edit your `~/.ssh/config` file to remove the `Include daytona_config entry`. You can do this manually by running the following command:
 
-    ```shell
-    nano ~/.ssh/config
-    ```
+```shell
+nano ~/.ssh/config
+```
 
-    Remove the local Daytona registry container by running the following command:
+Remove the local Daytona registry container by running the following command:
 
-    ```shell
-    docker rm /daytona-registry
-    ```
+```shell
+docker rm /daytona-registry
+```
 
-    If you have generated any autocomplete scripts for Daytona, you will need to remove them manually from your shell configuration files (e.g., `.bashrc`, `.zshrc`).
+If you have generated any autocomplete scripts for Daytona, you will need to remove them manually from your shell configuration files (e.g., `.bashrc`, `.zshrc`).

--- a/src/content/docs/installation/method/uninstall-unix.mdx
+++ b/src/content/docs/installation/method/uninstall-unix.mdx
@@ -15,33 +15,33 @@ Ensure you have a backup of any Workspace data and relevant configuration before
 
 1. Run the following commands to purge local Daytona data and remove the binary:
 
-    ```shell
-    daytona purge
-    ```
+```shell
+daytona purge
+```
 
-    Run the following commands if the `daytona purge` command does not work, or if you want to manually purge local Daytona data and remove the binary:
+Run the following commands if the `daytona purge` command does not work, or if you want to manually purge local Daytona data and remove the binary:
 
-    ```shell
-    rm -rf ~/Library/Application\ Support/daytona
-    sudo rm $(whereis daytona | awk '{print $2}')
-    ```
+```shell
+rm -rf ~/Library/Application\ Support/daytona
+sudo rm $(whereis daytona | awk '{print $2}')
+```
 
-    Additionally, to fully remove all Daytona-related configurations and components, run the following command:
+Additionally, to fully remove all Daytona-related configurations and components, run the following command:
 
-    ```shell
-    rm -f ~/.ssh/daytona_config
-    ```
+```shell
+rm -f ~/.ssh/daytona_config
+```
 
-    Edit your `~/.ssh/config` file to remove the `Include daytona_config entry`. You can do this manually by running the following command:
+Edit your `~/.ssh/config` file to remove the `Include daytona_config entry`. You can do this manually by running the following command:
 
-    ```shell
-    nano ~/.ssh/config
-    ```
+```shell
+nano ~/.ssh/config
+```
 
-    Remove the local Daytona registry container by running the following command:
+Remove the local Daytona registry container by running the following command:
 
-    ```shell
-    docker rm /daytona-registry
-    ```
+```shell
+docker rm /daytona-registry
+```
 
-    If you have generated any autocomplete scripts for Daytona, you will need to remove them manually from your shell configuration files (e.g., `.bashrc`, `.zshrc`).
+If you have generated any autocomplete scripts for Daytona, you will need to remove them manually from your shell configuration files (e.g., `.bashrc`, `.zshrc`).

--- a/src/content/docs/usage/builders.mdx
+++ b/src/content/docs/usage/builders.mdx
@@ -40,7 +40,7 @@ When choosing this option, Daytona uses the following logic to determine which B
 To use the Automatic Builder, set the `--builder` flag value to `auto` during the [Workspace creation](/usage/workspaces#create-a-workspace). This flag only applies when creating Workspaces with a single Project.
 
 ```shell
-   daytona create <REPO_URL> --builder=auto
+daytona create <REPO_URL> --builder=auto
 ```
 
 ## Dev Container Builder
@@ -50,13 +50,13 @@ The following option is available when using this Builder:
 
 1. **Devcontainer file path**
 
-   The path where the Dev Container configuration is located, relative to the repository root.
-   The default value is `.devcontainer/devcontainer.json`.
+The path where the Dev Container configuration is located, relative to the repository root.
+The default value is `.devcontainer/devcontainer.json`.
 
 To use the Dev Container Builder, set the `--devcontainer-path` flag to the Dev Container configuration path within the repository during the [Workspace creation](/usage/workspaces#create-a-workspace). This flag only applies when creating Workspaces with a single Project.
 
 ```shell
-   daytona create <REPO_URL> --devcontainer-path=.devcontainer/devcontainer.json
+daytona create <REPO_URL> --devcontainer-path=.devcontainer/devcontainer.json
 ```
 
 <Aside type="tip">
@@ -73,23 +73,23 @@ The following options are accepted when using this Builder:
 
 1. **Custom container image**
 
-   The name of the base container image for the Project.
+The name of the base container image for the Project.
 
 2. **Container user**
 
-   The user to execute commands as during the image build process.
+The user to execute commands as during the image build process.
 
 3. **Post start commands**
 
-   Commands to execute once the Project is started.
+Commands to execute once the Project is started.
 
 4. **Environment variables**
-   A list of environment variables in the format `KEY=VALUE`.
+A list of environment variables in the format `KEY=VALUE`.
 
 To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags during the [Workspace creation](/usage/workspaces#create-a-workspace). These flags only apply when creating Workspaces with a single Project.
 
 ```shell
-   daytona create <REPO_URL> --custom-image=daytona-workspace:latest --custom-image-user=daytona
+daytona create <REPO_URL> --custom-image=daytona-workspace:latest --custom-image-user=daytona
 ```
 
 ## None
@@ -108,37 +108,37 @@ After an image is built, it will be uploaded to the configured container registr
 
 1. Execute the following command to configure the custom build registry:
 
-   ```shell
-   daytona container-registry set
-   ```
+```shell
+daytona container-registry set
+```
 
 2. Set the required options:
-   1. **Server URL**
+1. **Server URL**
 
-      The full URL to your custom container registry.
+The full URL to your custom container registry.
 
-   2. **Username**
+2. **Username**
 
-      The username Daytona should use to log in to the container registry.
+The username Daytona should use to log in to the container registry.
 
-   3. **Password**
+3. **Password**
 
-      The password for your container registry account.
+The password for your container registry account.
 
 3. Press `Enter` to set the custom build registry.
 4. Execute the following command to configure the server:
 
-   ```shell
-   daytona server configure
-   ```
+```shell
+daytona server configure
+```
 
 5. Press `Enter` until the "Builder Registry" section is highlighted.
 
-   ```text
-      ┃ Builder Registry
-      ┃ To add options, add a container registry with 'daytona cr set'
-      ┃ > Local registry managed by Daytona
-   ```
+```text
+Builder Registry
+To add options, add a container registry with 'daytona cr set'
+> Local registry managed by Daytona
+```
 
 6. Select the custom registry configured previously using `Up`/`Down`.
 7. Press `Enter` until the command exits to save the configuration.

--- a/src/content/docs/usage/ide.mdx
+++ b/src/content/docs/usage/ide.mdx
@@ -34,30 +34,30 @@ You can set the default IDE used by Daytona.
 
 1. Run the following command to set the default IDE:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-   Upon running this command, Daytona will display a list of available IDEs, allowing you to select your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select your default choice.
 
-   ```text
-        Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-        VS Code
-        VS Code - Browser
-        Terminal SSH
-        CLion
-        GoLand
-        ...
-   ```
+VS Code
+VS Code - Browser
+Terminal SSH
+CLion
+GoLand
+...
+```
 
 2. Select your preferred IDE from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-   ```text
-    Default IDE:  VS Code
-   ```
+```text
+Default IDE:  VS Code
+```
 
-   You can now use the `daytona code` command to automatically open the default IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the default IDE already connected to your Workspace.
 
 ## VS Code
 
@@ -65,25 +65,25 @@ Daytona allows you to connect to your Workspace using Visual Studio Code (VSCode
 
 1. Run the following command to set your default IDE to VS Code:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `VS Code` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `VS Code` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | VS Code
-    ```
+| VS Code
+```
 
 2. Select `VS Code` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE:  VS Code
-    ```
+```text
+Default IDE:  VS Code
+```
 
-    You can now use the `daytona code` command to automatically open the default IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the default IDE already connected to your Workspace.
 
 ## VS Code Browser
 
@@ -91,31 +91,29 @@ Daytona allows you to connect to your Workspace using Visual Studio Code (VSCode
 
 1. Run the following command to set your default IDE to VSCode Browser:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `VS Code - Browser` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `VS Code - Browser` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | VS Code - Browser
-    ```
+| VS Code - Browser
+```
 
 2. Select `VS Code - Browser` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE:  VS Code - Browser
-    ```
+```text
+Default IDE:  VS Code - Browser
+```
 
-    You can now use the `daytona code` command to automatically open the VS Code - Browser IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the VS Code - Browser IDE already connected to your Workspace.
 
-    <br />
-
-    :::note
-      When using the `daytona code` command with `VS Code - Browser` as your default IDE, Daytona will install OpenVSCode Server inside your project, forward the appropriate port to your local machine, and open your default browser automatically.
-    :::
+:::note
+When using the `daytona code` command with `VS Code - Browser` as your default IDE, Daytona will install OpenVSCode Server inside your project, forward the appropriate port to your local machine, and open your default browser automatically.
+:::
 
 ## JetBrains CLion
 
@@ -123,25 +121,25 @@ Daytona allows you to connect to your Workspace using JetBrains CLion IDE.
 
 1. Run the following command to set your default IDE to JetBrains CLion:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `CLion` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `CLion` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | CLion
-    ```
+| CLion
+```
 
 2. Select `CLion` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE:  CLion
-    ```
+```text
+Default IDE:  CLion
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains CLion IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains CLion IDE already connected to your Workspace.
 
 ## JetBrains GoLand
 
@@ -149,25 +147,25 @@ Daytona allows you to connect to your Workspace using JetBrains GoLand IDE.
 
 1. Run the following command to set your default IDE to JetBrains GoLand:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `GoLand` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `GoLand` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | GoLand
-    ```
+| GoLand
+```
 
 2. Select `GoLand` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE:  GoLand
-    ```
+```text
+Default IDE:  GoLand
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains GoLand IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains GoLand IDE already connected to your Workspace.
 
 ## JetBrains IntelliJ IDEA Ultimate
 
@@ -175,25 +173,25 @@ Daytona allows you to connect to your Workspace using JetBrains IntelliJ IDEA Ul
 
 1. Run the following command to set your default IDE to JetBrains IntelliJ IDEA Ultimate:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `IntelliJ IDEA Ultimate` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `IntelliJ IDEA Ultimate` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | IntelliJ IDEA Ultimate
-    ```
+| IntelliJ IDEA Ultimate
+```
 
 2. Select `IntelliJ IDEA Ultimate` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: IntelliJ IDEA Ultimate
-    ```
+```text
+Default IDE: IntelliJ IDEA Ultimate
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains IntelliJ IDEA Ultimate IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains IntelliJ IDEA Ultimate IDE already connected to your Workspace.
 
 ## JetBrains PhpStorm
 
@@ -201,25 +199,25 @@ Daytona allows you to connect to your Workspace using JetBrains PhpStorm IDE.
 
 1. Run the following command to set your default IDE to JetBrains PhpStorm:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `PhpStorm` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `PhpStorm` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | PhpStorm
-    ```
+| PhpStorm
+```
 
 2. Select `PhpStorm` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: PhpStorm
-    ```
+```text
+Default IDE: PhpStorm
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains PhpStorm IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains PhpStorm IDE already connected to your Workspace.
 
 ## JetBrains PyCharm Professional
 
@@ -227,25 +225,25 @@ Daytona allows you to connect to your Workspace using JetBrains PyCharm Professi
 
 1. Run the following command to set your default IDE to JetBrains PyCharm Professional:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `PyCharm Professional` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `PyCharm Professional` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | PyCharm Professional
-    ```
+| PyCharm Professional
+```
 
 2. Select `PyCharm Professional` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: PyCharm Professional
-    ```
+```text
+Default IDE: PyCharm Professional
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains PyCharm Professional IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains PyCharm Professional IDE already connected to your Workspace.
 
 ## JetBrains Rider
 
@@ -253,25 +251,25 @@ Daytona allows you to connect to your Workspace using JetBrains Rider IDE.
 
 1. Run the following command to set your default IDE to JetBrains Rider:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `Rider` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `Rider` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | Rider
-    ```
+| Rider
+```
 
 2. Select `Rider` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: Rider
-    ```
+```text
+Default IDE: Rider
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains Rider IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains Rider IDE already connected to your Workspace.
 
 ## JetBrains RubyMine
 
@@ -279,25 +277,25 @@ Daytona allows you to connect to your Workspace using JetBrains RubyMine IDE.
 
 1. Run the following command to set your default IDE to JetBrains RubyMine:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `RubyMine` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `RubyMine` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | RubyMine
-    ```
+| RubyMine
+```
 
 2. Select `RubyMine` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: RubyMine
-    ```
+```text
+Default IDE: RubyMine
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains RubyMine IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains RubyMine IDE already connected to your Workspace.
 
 ## JetBrains WebStorm
 
@@ -305,25 +303,25 @@ Daytona allows you to connect to your Workspace using JetBrains WebStorm IDE.
 
 1. Run the following command to set your default IDE to JetBrains WebStorm:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `WebStorm` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `WebStorm` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | WebStorm
-    ```
+| WebStorm
+```
 
 2. Select `WebStorm` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: WebStorm
-    ```
+```text
+Default IDE: WebStorm
+```
 
-    You can now use the `daytona code` command to automatically open the JetBrains WebStorm IDE already connected to your Workspace.
+You can now use the `daytona code` command to automatically open the JetBrains WebStorm IDE already connected to your Workspace.
 
 ## Terminal SSH
 
@@ -331,22 +329,22 @@ Daytona allows you to connect to your Workspace through SSH.
 
 1. Run the following command to set your default IDE to Terminal SSH:
 
-   ```shell
-   daytona ide
-   ```
+```shell
+daytona ide
+```
 
-    Upon running this command, Daytona will display a list of available IDEs, allowing you to select `Terminal SSH` as your default choice.
+Upon running this command, Daytona will display a list of available IDEs, allowing you to select `Terminal SSH` as your default choice.
 
-    ```text
-      Choose Your Default IDE
+```text
+Choose Your Default IDE
 
-      | Terminal SSH
-    ```
+| Terminal SSH
+```
 
 2. Select `Terminal SSH` from the list presented. Upon selecting, Daytona will set it as the default IDE and display a confirmation message.
 
-    ```text
-    Default IDE: Terminal SSH
-    ```
+```text
+Default IDE: Terminal SSH
+```
 
-    You can now use the `daytona code` command to automatically start an SSH session already connected to your Workspace.
+You can now use the `daytona code` command to automatically start an SSH session already connected to your Workspace.

--- a/src/content/docs/usage/prebuilds.mdx
+++ b/src/content/docs/usage/prebuilds.mdx
@@ -15,35 +15,35 @@ Prebuilds work by registering a listener for webhook events from the Git Provide
 
 1. Run the following command to add a new Prebuild:
 
-   ```shell
-   daytona prebuilds add
-   ```
+```shell
+daytona prebuilds add
+```
 
-   Upon running the command, Daytona will prompt you to select a project configuration you plan to work on. You can then decide on a commit interval (e.g. `5`, _every 5 commits_) after which a build should be triggered, any specific trigger files whose changes should immediately start the build process, and build retention (the maximum number of builds to store at a time).
+Upon running the command, Daytona will prompt you to select a project configuration you plan to work on. You can then decide on a commit interval (e.g. `5`, _every 5 commits_) after which a build should be triggered, any specific trigger files whose changes should immediately start the build process, and build retention (the maximum number of builds to store at a time).
 
-   ```text
-   Select a Project Config To Prebuild
-   1 item
-   MyConfig
-   https://github.com/username/myproject.git
-   ```
+```text
+Select a Project Config To Prebuild
+1 item
+MyConfig
+https://github.com/username/myproject.git
+```
 
-   ```text
-   Commit interval
-   Leave blank to ignore push events
-   >
-   ```
+```text
+Commit interval
+Leave blank to ignore push events
+>
+```
 
-   ```text
-   Trigger Files
-   Enter full paths for files whose changes you want to explicitly trigger a prebuild. Use new lines for multiple entries.
-   ```
+```text
+Trigger Files
+Enter full paths for files whose changes you want to explicitly trigger a prebuild. Use new lines for multiple entries.
+```
 
-   ```text
-   Retention
-   Maximum number of resulting builds stored at a time
-   >
-   ```
+```text
+Retention
+Maximum number of resulting builds stored at a time
+>
+```
 
 Subsequent `daytona create` calls will automatically detect the most recent existing build and use it to create the project.
 
@@ -71,17 +71,17 @@ Daytona allows you to list all Prebuilds, providing you with an overview of the 
 
 1. Run the following command to list all Prebuilds:
 
-   ```shell
-   daytona prebuilds list
-   ```
+```shell
+daytona prebuilds list
+```
 
-   Upon running this command, Daytona will display a list of your Prebuilds. You will be able to view the project configuration, the branch it is linked to, the commit interval, the trigger files, and the build retention.
+Upon running this command, Daytona will display a list of your Prebuilds. You will be able to view the project configuration, the branch it is linked to, the commit interval, the trigger files, and the build retention.
 
-      ```text
-      Project Config   Branch  Commit Interval  Trigger files  Build Retention
-      ────────────────────────────────────────────────────────────────────────
-      MyConfig         main    5                None           3
-   ```
+```text
+Project Config   Branch  Commit Interval  Trigger files  Build Retention
+────────────────────────────────────────────────────────────────────────
+MyConfig         main    5                None           3
+```
 
 ## Prebuilds Information
 
@@ -89,30 +89,30 @@ Daytona allows you to view detailed information of a Prebuild, providing you wit
 
 1. Run the following command to view the details of a Prebuild:
 
-   ```shell
-   daytona prebuilds info
-   ```
+```shell
+daytona prebuilds info
+```
 
 2. Select the Prebuild you want to view.
 
-   ```text
-   Select a Prebuild To View
-   1 item
-   MyConfig (main)                                                              
-   abcd1234efg (every 5 commits)
-   ```
+```text
+Select a Prebuild To View
+1 item
+MyConfig (main)                                                              
+abcd1234efg (every 5 commits)
+```
 
-   Upon selecting the Prebuild, Daytona will display the details of the selected Prebuild. You will be able to view the Prebuild ID, the project configuration, the branch it is linked to, the commit interval, the trigger files, and the build retention.
+Upon selecting the Prebuild, Daytona will display the details of the selected Prebuild. You will be able to view the Prebuild ID, the project configuration, the branch it is linked to, the commit interval, the trigger files, and the build retention.
 
-   ```text
-   Prebuild Configuration Info                                                                   
-                                                                                                  
-   ID                   abcd1234efg
-   Project config       MyConfig
-   Branch               main
-   Commit interval      5
-   Build retention      3
-   ```
+```text
+Prebuild Configuration Info                                                                   
+                                                                                             
+ID                   abcd1234efg
+Project config       MyConfig
+Branch               main
+Commit interval      5
+Build retention      3
+```
 
 ## Update Prebuilds
 
@@ -120,42 +120,42 @@ Daytona allows you to update a Prebuild, helping you manage and modify the Prebu
 
 1. Run the following command to update a Prebuild:
 
-   ```shell
-   daytona prebuilds update
-   ```
+```shell
+daytona prebuilds update
+```
 
 2. Select the Prebuild you want to update.
 
-   ```text
-   Select a Prebuild To Update
-   1 item
-   MyConfig (main)                                                              
-   abcd1234efg (every 5 commits)
-   ```
+```text
+Select a Prebuild To Update
+1 item
+MyConfig (main)                                                              
+abcd1234efg (every 5 commits)
+```
 
-   Upon selecting the Prebuild, Daytona will prompt you to update the Prebuild commit interval, trigger files, and build retention.
+Upon selecting the Prebuild, Daytona will prompt you to update the Prebuild commit interval, trigger files, and build retention.
 
-   ```text
-   Commit interval
-   >
-   ```
+```text
+Commit interval
+>
+```
 
-   ```text
-   Trigger Files
-   Enter full paths for files whose changes you want to explicitly trigger a prebuild. Use new lines for multiple entries.
-   ```
+```text
+Trigger Files
+Enter full paths for files whose changes you want to explicitly trigger a prebuild. Use new lines for multiple entries.
+```
 
-   ```text
-   Retention
-   Maximum number of resulting builds stored at a time
-   >
-   ```
+```text
+Retention
+Maximum number of resulting builds stored at a time
+>
+```
 
-   Upon updating the Prebuild configuration, Daytona will display a success message.
+Upon updating the Prebuild configuration, Daytona will display a success message.
 
-   ```text
-   Prebuild updated successfully
-   ```
+```text
+Prebuild updated successfully
+```
 
 ## Delete Prebuilds
 
@@ -163,19 +163,19 @@ Daytona allows you to delete Prebuilds, helping you manage and remove those that
 
 1. Run the following command to delete a Prebuild:
 
-   ```shell
-   daytona prebuilds delete
-   ```
+```shell
+daytona prebuilds delete
+```
 
 2. Select the Prebuild you want to delete.
 
-   ```text
-   Select a Prebuild To Delete
-   1 item
-   MyConfig (main)
-   abcd1234efg (every 5 commits)
-   ```
+```text
+Select a Prebuild To Delete
+1 item
+MyConfig (main)
+abcd1234efg (every 5 commits)
+```
 
-   ```text
-   Prebuild deleted successfully
-   ```
+```text
+Prebuild deleted successfully
+```

--- a/src/content/docs/usage/projects.mdx
+++ b/src/content/docs/usage/projects.mdx
@@ -44,41 +44,41 @@ Daytona allows you to add a new Project Configuration, enabling you to store and
 
 1. Run the following command to add a new Project Configuration:
 
-   ```shell
-   daytona project-config add
-   ```
+```shell
+daytona project-config add
+```
 
 2. Enter the repository URL of the project you want to configure.
 
-   ```text
-      Git repository
-      >
-   ```
+```text
+Git repository
+>
+```
 
 3. Select the build configuration for the project.
 
-   ```text
-      Choose a build configuration
-      Automatic
-      Devcontainer
-      Custom image
-      None
-   ```
+```text
+Choose a build configuration
+Automatic
+Devcontainer
+Custom image
+None
+```
 
 4. Enter the environment variables for the project in the `KEY=VALUE` format.
 
-   ```text
-      Environment Variables
-      Enter environment variables in the format KEY=VALUE
-      To pass machine env variables at runtime, use $VALUE
-   ```
+```text
+Environment Variables
+Enter environment variables in the format KEY=VALUE
+To pass machine env variables at runtime, use $VALUE
+```
 
 5. Enter a name for the Project Configuration.
 
-   ```text
-      Project config name
-      >
-   ```
+```text
+Project config name
+>
+```
 
    Upon completion, Daytona will save the Project Configuration, allowing you to reuse it across multiple Workspaces.
 
@@ -88,32 +88,32 @@ Daytona allows you to view detailed information of a Project Configuration, prov
 
 1. Run the following command to view the details of a Project Configuration:
 
-   ```shell
-   daytona project-config info
-   ```
+```shell
+daytona project-config info
+```
 
-   Upon running this command, Daytona will display a list of your Project Configurations
+Upon running this command, Daytona will display a list of your Project Configurations
 
 2. Select the Project Configuration you want to view.
 
-   ```text
-      Select a Project Config To View
-      1 item
+```text
+Select a Project Config To View
+1 item
 
-      ┃  MyProjectConfig
-      ┃  https://github.com/username/MyProject
-   ```
+┃  MyProjectConfig
+┃  https://github.com/username/MyProject
+```
 
    Upon selecting the Project Configuration, Daytona will display the details of the selected configuration. You will be able to view the Project Configuration name, the repository URL it is linked to, the build configuration, and the Devcontainer path.
 
-   ```text
-      Project Config Info
+```text
+Project Config Info
 
-      Name                    MyProjectConfig
-      Repository              https://github.com/username/MyProject
-      Build                   Devcontainer
-      Devcontainer path       .devcontainer/devcontainer.json
-   ```
+Name                    MyProjectConfig
+Repository              https://github.com/username/MyProject
+Build                   Devcontainer
+Devcontainer path       .devcontainer/devcontainer.json
+```
 
 ## List Project Configuration
 
@@ -121,17 +121,17 @@ Daytona allows you to list all Project Configurations, providing you with an ove
 
 1. Run the following command to list all Project Configurations:
 
-   ```shell
-   daytona project-config list
-   ```
+```shell
+daytona project-config list
+```
 
-   Upon running this command, Daytona will display a list of your Project Configurations. You will be able to view the Project Configuration name, the repository URL it is connected to, the build configuration, and if it is set as a default configuration.
+Upon running this command, Daytona will display a list of your Project Configurations. You will be able to view the Project Configuration name, the repository URL it is connected to, the build configuration, and if it is set as a default configuration.
 
-   ```text
-      Name                Repository             Build             Default
-      ─────────────────────────────────────────────────────────────────────
-      MyProjectConfig     daytonaio/daytona      Devcontainer      Yes
-   ```
+```text
+Name                Repository             Build             Default
+─────────────────────────────────────────────────────────────────────
+MyProjectConfig     daytonaio/daytona      Devcontainer      Yes
+```
 
 ## Set Default Project Configuration
 
@@ -139,25 +139,25 @@ Daytona allows you to set a default Project Configuration, enabling you to defin
 
 1. Run the following command to set a default Project Configuration:
 
-   ```shell
-   daytona project-config set-default
-   ```
+```shell
+daytona project-config set-default
+```
 
 2. Select the Project Configuration you want to set as the default.
 
-   ```text
-      Select a Project Config To Set As Default
-      1 item
+```text
+Select a Project Config To Set As Default
+1 item
 
-      ┃  MyProjectConfig
-      ┃  https://github.com/username/MyProject
-   ```
+┃  MyProjectConfig
+┃  https://github.com/username/MyProject
+```
 
    Upon selecting the default Project Configuration, Daytona will set it as the default configuration for new Workspaces.
 
-   ```text
-      Project config 'MyProjectConfig' set as default
-   ```
+```text
+Project config 'MyProjectConfig' set as default
+```
 
 ## Update Project Configuration
 
@@ -165,41 +165,41 @@ Daytona allows you to update an existing Project Configuration, enabling you to 
 
 1. Run the following command to update a Project Configuration:
 
-   ```shell
-   daytona project-config update
-   ```
+```shell
+daytona project-config update
+```
 
 2. Select the Project Configuration you want to update.
 
-   ```text
-      Select a Project Config To Update
-      1 item
+```text
+Select a Project Config To Update
+1 item
 
-      ┃  MyProjectConfig
-      ┃  https://github.com/username/MyProject
-   ```
+┃  MyProjectConfig
+┃  https://github.com/username/MyProject
+```
 
 3. Update the properties of the Project Configuration.
 
-   ```text
-      Choose a build configuration
-      Automatic
-      Devcontainer
-      Custom image
-      None
-   ```
+```text
+Choose a build configuration
+Automatic
+Devcontainer
+Custom image
+None
+```
 
-   ```text
-      Environment Variables
-      Enter environment variables in the format KEY=VALUE
-      To pass machine env variables at runtime, use $VALUE
-   ```
+```text
+Environment Variables
+Enter environment variables in the format KEY=VALUE
+To pass machine env variables at runtime, use $VALUE
+```
 
-   Upon completion, Daytona will save the updated Project Configuration, allowing you to reuse it across Workspaces.
+Upon completion, Daytona will save the updated Project Configuration, allowing you to reuse it across Workspaces.
 
-   ```text
-      Project config updated successfully
-   ```
+```text
+Project config updated successfully
+```
 
 ## Delete Project Configuration
 
@@ -207,20 +207,20 @@ Daytona allows you to delete an existing Project Configuration, enabling you to 
 
 1. Run the following command to delete a Project Configuration:
 
-   ```shell
-   daytona project-config delete
-   ```
+```shell
+daytona project-config delete
+```
 
 2. Select the Project Configuration you want to delete.
 
-   ```text
-      Select a Project Config To Delete
-      1 item
+```text
+Select a Project Config To Delete
+1 item
 
-      ┃  MyProjectConfig
-      ┃  https://github.com/username/MyProject
-   ```
+┃  MyProjectConfig
+┃  https://github.com/username/MyProject
+```
 
-   ```text
-      Project config deleted successfully
-   ```
+```text
+Project config deleted successfully
+```

--- a/src/content/docs/usage/server.mdx
+++ b/src/content/docs/usage/server.mdx
@@ -14,13 +14,13 @@ The primary method of interacting with the server is through the Daytona CLI. Us
 Run the following command to start the Daytona Server:
 
 ```shell
-  daytona server start
+daytona server start
 ```
 
 Upon running this command, Daytona will start the The Daytona Server daemon.
 
 ```text
-    Starting the Daytona Server daemon...
+Starting the Daytona Server daemon...
 ```
 
 ## Configure the Server
@@ -29,32 +29,32 @@ The Daytona Server configuration is located in different directories depending o
 
 - On macOS, the configuration file is located at:
 
-    `~/Library/Application\ Support/daytona/server/config.json`.
+    `~/Library/Application\ Support/daytona/server/config.json`
 
 - On Linux, the configuration file is located at:
 
-    `~/.config/daytona/server/config.json`.
+    `~/.config/daytona/server/config.json`
 
 - On Windows, the configuration file is located at:
 
-    `C:\Users\YOUR_USERNAME\AppData\Roaming\daytona\server\config.json`.
+    `C:\Users\YOUR_USERNAME\AppData\Roaming\daytona\server\config.json`
 
 The Daytona Server configuration can be viewed by using the following command across all operating systems:
 
 ```shell
-  daytona server config
+daytona server config
 ```
 
 The Daytona Server configuration contains the following properties:
 
 - **Server ID**
-  
+
     A unique identifier for the Daytona server instance.
 
     Example: `12a34bc5-d67e-890f-1gh2-34i5jk6l7m89`
 
 - **API URL**
-  
+
     The URL endpoint for the Daytona API.
 
     Example: `https://api-12a34bc5-d67e-890f-1gh2-34i5jk6l7m89.try-eu.daytona.app`
@@ -62,7 +62,7 @@ The Daytona Server configuration contains the following properties:
     The API URL property cannot be manually edited, but you can use it to connect to Daytona with other clients.
 
 - **API Port**
-  
+
     The port number on which the Daytona API is accessible.
 
     Example: `3986`
@@ -70,7 +70,7 @@ The Daytona Server configuration contains the following properties:
     If you have something running on port 3986, you can change it to a port that you have available.
 
 - **Default Project Image**
-  
+
     The default Docker image used for projects.
 
     Example: `daytonaio/workspace-project:latest`
@@ -78,7 +78,7 @@ The Daytona Server configuration contains the following properties:
     The Default Project Image property can be manually edited to use a different default project image.
 
 - **Default Project User**
-  
+
     The default user for projects.
 
     Example: `daytona`
@@ -86,7 +86,7 @@ The Daytona Server configuration contains the following properties:
     The Default Project User property can be manually edited to use a different default project user.
 
 - **FRPS Domain**
-  
+
     The domain used by the FRP (Fast Reverse Proxy) server.
 
     Example: `try-eu.daytona.app`
@@ -94,7 +94,7 @@ The Daytona Server configuration contains the following properties:
     The FRPS Domain property can be manually edited to use a different FRP domain.
 
 - **FRPS Port**
-  
+
     The port used by the FRP (Fast Reverse Proxy) server.
 
     Example: `7000`
@@ -102,7 +102,7 @@ The Daytona Server configuration contains the following properties:
     The FRPS Port property can be manually edited to use a different FRP port.
 
 - **FRPS Protocol**
-  
+
     The protocol used by the FRP (Fast Reverse Proxy) server.
 
     Example: `https`
@@ -110,7 +110,7 @@ The Daytona Server configuration contains the following properties:
     The FRPS Protocol property can be manually edited to use a different FRP protocol.
 
 - **Headscale Port**
-  
+
     The port number for the Headscale service.
 
     Example: `3987`
@@ -118,7 +118,7 @@ The Daytona Server configuration contains the following properties:
     The Headscale Port property can be manually edited to use a different Headscale port.
 
 - **Binaries Path**
-  
+
     The directory path where server binaries are stored.
 
     Example: `/Users/Library/Application Support/daytona/server/binaries`
@@ -126,7 +126,7 @@ The Daytona Server configuration contains the following properties:
     The Binaries Path directory will be created if it does not exist, and the property can be manually edited to use a different binaries path.
 
 - **Log File Path**
-  
+
     The directory path where server logs are stored.
 
     Example: `/Users/Library/Application Support/daytona/server/daytona.log`
@@ -134,7 +134,7 @@ The Daytona Server configuration contains the following properties:
     The Log File Path file will be created if it does not exist, and the property can be manually edited to use a different log file path.
 
 - **Builder Image**
-  
+
     The Docker image used by the local builder.
 
     Example: `daytonaio/workspace-project:latest`
@@ -142,7 +142,7 @@ The Daytona Server configuration contains the following properties:
     The Builder Image property can be manually edited to use a different builder image.
 
 - **Local Builder Registry Port**
-  
+
     The port number for the local builder registry.
 
     Example: `3988`
@@ -150,7 +150,7 @@ The Daytona Server configuration contains the following properties:
     The Local Builder Registry Port property is only displayed if the Builder Registry is set to local. It can be manually edited to use a different local builder registry port.
 
 - **Local Builder Registry Image**
-  
+
     The registry image used by the local builder registry.
 
     Example: `registry:2.3.8`
@@ -158,7 +158,7 @@ The Daytona Server configuration contains the following properties:
     The Local Builder Registry Image property is only displayed if the Builder Registry is set to local. It can be manually edited to use a different local builder registry image.
 
 - **Build Image Namespace**
-  
+
     The namespace for build images. This is used to organize and manage images within a specific scope.
 
     Example: `daytona`
@@ -166,19 +166,19 @@ The Daytona Server configuration contains the following properties:
     The Build Image Namespace property can be manually edited to use a different build image namespace.
 
 - **Providers Dir**
-  
+
     The directory path where provider configuration is stored.
 
     Example: `/Users/Library/Application Support/daytona/providers`
 
 - **Registry URL**
-  
-   The URL for the Daytona registry.
+
+    The URL for the Daytona registry.
 
     Example: `https://download.daytona.io/daytona`
 
 - **Server Download URL**
-  
+
     The URL for downloading the Daytona server.
 
     Example: `https://download.daytona.io/daytona/install.sh`
@@ -189,73 +189,73 @@ The Daytona Server configuration can be manually edited by using the following c
 daytona server configure
 ```
 
-  ```text  
-    Providers Directory
-    Directory will be created if it does not exist
-    > /Users/Library/Application Support/daytona/providers
+```text  
+Providers Directory
+Directory will be created if it does not exist
+> /Users/Library/Application Support/daytona/providers
 
-    Providers Directory
-    > /Users/Library/Application Support/daytona/providers
+Providers Directory
+> /Users/Library/Application Support/daytona/providers
 
-    Registry URL
-    > https://download.daytona.io/daytona
+Registry URL
+> https://download.daytona.io/daytona
 
-    Server Download URL
-    > https://download.daytona.io/daytona/install.sh
+Server Download URL
+> https://download.daytona.io/daytona/install.sh
 
-    Default Project Image
-    > daytonaio/workspace-project:latest
+Default Project Image
+> daytonaio/workspace-project:latest
 
-    Default Project User
-    > daytona
+Default Project User
+> daytona
 
-    Builder Image
-    Image dependencies: docker, @devcontainers/cli (node package)
-    > daytonaio/workspace-project:latest
+Builder Image
+Image dependencies: docker, @devcontainers/cli (node package)
+> daytonaio/workspace-project:latest
 
-    Builder Registry
-    To add options, add a container registry with 'daytona cr set'
-    > Local registry managed by Daytona
+Builder Registry
+To add options, add a container registry with 'daytona cr set'
+> Local registry managed by Daytona
 
-    Build Image Namespace
-    Namespace to be used when tagging and pushing build images
-    >
+Build Image Namespace
+Namespace to be used when tagging and pushing build images
+>
 
-    Local Builder Registry Port
-    > 3988
+Local Builder Registry Port
+> 3988
 
-    Local Builder Registry Image
-    > registry:0.0.0
+Local Builder Registry Image
+> registry:0.0.0
 
-    API Port
-    > 3986
+API Port
+> 3986
 
-    Headscale Port
-    > 3987
+Headscale Port
+> 3987
 
-    Binaries Path
-    Directory will be created if it does not exist
-    > /Users/Library/Application Support/daytona/server/binaries
+Binaries Path
+Directory will be created if it does not exist
+> /Users/Library/Application Support/daytona/server/binaries
 
-    Log File Path
-    File will be created if it does not exist
-    > /Users/Library/Application Support/daytona/server/daytona.log
+Log File Path
+File will be created if it does not exist
+> /Users/Library/Application Support/daytona/server/daytona.log
 
-    Frps Domain
-    > try-eu.daytona.app
+Frps Domain
+> try-eu.daytona.app
 
-    Frps Port
-    > 7000
+Frps Port
+> 7000
 
-    Frps Protocol
-    > https
-  ```
+Frps Protocol
+> https
+```
 
 Upon successful configuration, Daytona will validate the settings and ensure all specified directories and files are correctly set up, preparing the server for optimal operation.
 
-  ```text
-    Server configuration updated. You need to restart the server for the changes to take effect.
-  ```
+```text
+Server configuration updated. You need to restart the server for the changes to take effect.
+```
 
 Use the `daytona server restart` command to restart the server for the changes to take effect.
 
@@ -264,15 +264,15 @@ Use the `daytona server restart` command to restart the server for the changes t
 Run the following command to restart the Daytona Server:
 
 ```shell
-  daytona server restart
+daytona server restart
 ```
 
 Upon running this command, Daytona will automatically stop and start The Daytona Server daemon.
 
 ```text
-    Stopping the Daytona Server daemon...
-    Starting the Daytona Server daemon...
-    Daytona Server daemon restarted successfully
+Stopping the Daytona Server daemon...
+Starting the Daytona Server daemon...
+Daytona Server daemon restarted successfully
 ```
 
 ## Stop the Server
@@ -280,11 +280,11 @@ Upon running this command, Daytona will automatically stop and start The Daytona
 Run the following command to stop the Daytona Server:
 
 ```shell
-  daytona server stop
+daytona server stop
 ```
 
 Upon running this command, Daytona will stop the Daytona Server daemon.
 
 ```text
-    Stopping the Daytona Server daemon...
+Stopping the Daytona Server daemon...
 ```

--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -27,65 +27,63 @@ Creating a Workspace allows you to set up a new environment either by selecting 
 
 1. Run the following command to start the guided Workspace creation process:
 
-   ```shell
-   daytona create
-   ```
+```shell
+daytona create
+```
 
-   <Aside type="tip">
-      You can open a new Workspace in an [IDE](/usage/ide) by using the `--code` flag.
+<Aside type="tip">
+You can open a new Workspace in an [IDE](/usage/ide) by using the `--code` flag.
 
-      ```shell
-      daytona create --code
-      ```
+```shell
+daytona create --code
+```
 
-   </Aside>
+</Aside>
 
-   <br />
+<br />
 
 2. Select the Git Provider you want to use or select to enter a custom repository URL. Daytona provides two options for linking your repository:
 
-   - **Selecting from a List of Repositories**
+- **Selecting from a List of Repositories**
 
-     If you choose a Git provider (e.g., GitHub), you will be presented with a list of your repositories from which you can select the desired repository.
+   If you choose a Git provider (e.g., GitHub), you will be presented with a list of your repositories from which you can select the desired repository.
 
-   - **Entering a Custom Repository URL**
+- **Entering a Custom Repository URL**
 
-     Alternatively, you can select the option to enter a custom repository URL manually if the repository is not listed under your Git provider account or is from an external source.
+   Alternatively, you can select the option to enter a custom repository URL manually if the repository is not listed under your Git provider account or is from an external source.
 
-   ```text
-      Choose a Provider
-      2 items
-      ===
-      GitHub
-      Enter a custom repository URL
-   ```
+```text
+Choose a Provider
+2 items
+===
+GitHub
+Enter a custom repository URL
+```
 
 3. Select the repository from the list or enter the URL of the Git repository you want to link with your Workspace.
 
 4. Enter a name for your Workspace.
 
-   <br />
+<Aside type="note">
+   You can press `F10` to configure advanced settings for your Workspace,
+   including setting the [Builder](/usage/builders).
+</Aside>
 
-   <Aside type="note">
-     You can press `F10` to configure advanced settings for your Workspace,
-     including setting the [Builder](/usage/builders).
-   </Aside>
-
-   <br />
+<br />
 
 5. Wait while Daytona sets up your Workspace. It handles all the initialization and configuration of your environment.
 
-   ```text
-      WORKSPACE | ✓ Request submitted
-      WORKSPACE | ✓ Creating workspace daytona
-      daytona   | Creating project daytona
-      daytona   | Pulling image...
-      daytona   | Pulling from daytonaio/workspace-project
-      ...
-      daytona   | Project daytona created
-      daytona   | Starting project daytona
-      daytona   | Project daytona started
-   ```
+```text
+WORKSPACE | ✓ Request submitted
+WORKSPACE | ✓ Creating workspace daytona
+daytona   | Creating project daytona
+daytona   | Pulling image...
+daytona   | Pulling from daytonaio/workspace-project
+...
+daytona   | Project daytona created
+daytona   | Starting project daytona
+daytona   | Project daytona started
+```
 
 ### From an Arbitrary Git URL
 
@@ -93,34 +91,34 @@ Creating a Workspace from an arbitrary Git URL allows you to set up a new enviro
 
 1. Run the following command to create a Workspace from a remote Git repository:
 
-   ```shell
-   daytona create <REPO_URL>
-   ```
+```shell
+daytona create <REPO_URL>
+```
 
-   **Example**
+**Example**
 
-   ```shell
-   daytona create https://github.com/daytonaio/daytona.git
-   ```
+```shell
+daytona create https://github.com/daytonaio/daytona.git
+```
 
-   Upon running this command, Daytona will clone the specified Git repository and set up a new Workspace based on its contents. You will see progress information in the terminal, indicating the process of the Workspace creation. Once complete, the Workspace will be ready for use with the specified repository.
+Upon running this command, Daytona will clone the specified Git repository and set up a new Workspace based on its contents. You will see progress information in the terminal, indicating the process of the Workspace creation. Once complete, the Workspace will be ready for use with the specified repository.
 
-   ```text
-      WORKSPACE | ✓ Request submitted
-      WORKSPACE | ✓ Creating workspace daytona
-      daytona   | Creating project daytona
-      daytona   | Pulling image...
-      daytona   | Pulling from daytonaio/workspace-project
-      ...
-      daytona   | Project daytona created
-      daytona   | Starting project daytona
-      daytona   | Project daytona started
-   ```
+```text
+WORKSPACE | ✓ Request submitted
+WORKSPACE | ✓ Creating workspace daytona
+daytona   | Creating project daytona
+daytona   | Pulling image...
+daytona   | Pulling from daytonaio/workspace-project
+...
+daytona   | Project daytona created
+daytona   | Starting project daytona
+daytona   | Project daytona started
+```
 
-   <Aside type="tip">
-   You can set the Project Builder at Workspace creation time using command-line
-   flags. Refer to **[Builders](/usage/builders)** for more information.
-   </Aside>
+<Aside type="tip">
+You can set the Project Builder at Workspace creation time using command-line
+flags. Refer to **[Builders](/usage/builders)** for more information.
+</Aside>
 
 ## List Workspaces
 
@@ -128,17 +126,17 @@ Daytona allows you to keep track of your development environments by listing all
 
 1. Run the following command:
 
-   ```shell
-   daytona list
-   ```
+```shell
+daytona list
+```
 
-   Upon running this command, Daytona will display a list of your Workspaces with their details. You will be able to see the Workspace name, the repository it is connected to, the target of the Workspace, and its status.
+Upon running this command, Daytona will display a list of your Workspaces with their details. You will be able to see the Workspace name, the repository it is connected to, the target of the Workspace, and its status.
 
-   ```text
-      Workspace        Repository          Target     Status
-      ─────────────────────────────────────────────────────────────────────
-      MyWorkspace      username/MyProject  local      RUNNING (30 minutes)
-   ```
+```text
+Workspace        Repository          Target     Status
+─────────────────────────────────────────────────────────────────────
+MyWorkspace      username/MyProject  local      RUNNING (30 minutes)
+```
 
 ## Open An Existing Workspace
 
@@ -146,21 +144,20 @@ Daytona allows you to open an existing Workspace in your IDE. This enables you t
 
 1. Run the following command:
 
-   ```shell
-   daytona code
-   ```
+```shell
+daytona code
+```
 
-   Upon running this command, Daytona will display a list of your Workspaces with their details. You will be able to see the Workspace name, the unique identifier of the Workspace, and the repository it is connected to.
+Upon running this command, Daytona will display a list of your Workspaces with their details. You will be able to see the Workspace name, the unique identifier of the Workspace, and the repository it is connected to.
 
-   ```text
-      Select a Workspace To Open
-      1 item
+```text
+Select a Workspace To Open
+1 item
 
-      ┃  MyProject
-      ┃  abcdefg12hi3 (local)
-      ┃  github.com/username/MyProject.git
-
-   ```
+┃  MyProject
+┃  abcdefg12hi3 (local)
+┃  github.com/username/MyProject.git
+```
 
 2. Select the Workspace you want to open.
 
@@ -175,45 +172,44 @@ Daytona allows you to delete one or more Workspaces, helping you manage your dev
 
 1. Run the following command:
 
-   ```shell
-   daytona delete
-   ```
+```shell
+daytona delete
+```
 
-   Upon running this command, Daytona will display a list of your Workspaces with their details. You will be able to see the Workspace name, the unique identifier of the Workspace, and the repository it is connected to.
+Upon running this command, Daytona will display a list of your Workspaces with their details. You will be able to see the Workspace name, the unique identifier of the Workspace, and the repository it is connected to.
 
-   ```text
-      Select Workspaces To Delete
-      1 item
+```text
+Select Workspaces To Delete
+1 item
 
-      ┃ MyWorkspace
-      ┃ abcdefg12hi3 (local)
-      ┃ github.com/username/MyProject.git
-
-   ```
+┃ MyWorkspace
+┃ abcdefg12hi3 (local)
+┃ github.com/username/MyProject.git
+```
 
 2. Mark Workspaces for deletion by highlighting them and pressing `x`.
 
 3. Press `Enter` on the selected Workspace to delete it.
 
-   ```text
-      Delete: MyWorkspace
+```text
+Delete: MyWorkspace
 
-      ┃  abcdefg12hi3 (local)
-      ┃  github.com/username/MyProject.git
-   ```
+┃  abcdefg12hi3 (local)
+┃  github.com/username/MyProject.git
+```
 
 4. Confirm the action.
 
-   ```text
-      Delete workspace(s): [MyWorkspace]?
-      Are you sure you want to delete the workspace(s): [MyWorkspace]?
+```text
+Delete workspace(s): [MyWorkspace]?
+Are you sure you want to delete the workspace(s): [MyWorkspace]?
 
-      [Yes]   [No]
-   ```
+[Yes]   [No]
+```
 
-   ```text
-      Workspace MyWorkspace successfully deleted
-   ```
+```text
+Workspace MyWorkspace successfully deleted
+```
 
 ### Non-Interactively
 
@@ -221,24 +217,24 @@ Daytona allows you to delete one or more existing Workspaces non-interactively, 
 
 1. Run the following command, specifying the workspace names/UUIDs to delete:
 
-   ```shell
-   daytona delete WORKSPACE_1 WORKSPACE_2
-   ```
+```shell
+daytona delete WORKSPACE_1 WORKSPACE_2
+```
 
-   Upon running this command, Daytona will prompt you to confirm the deletion of the specified Workspace. You will be able to see the Workspace name that you are about to delete, and you will have the option to confirm or cancel the action.
+Upon running this command, Daytona will prompt you to confirm the deletion of the specified Workspace. You will be able to see the Workspace name that you are about to delete, and you will have the option to confirm or cancel the action.
 
-   ```text
-      Delete workspace(s): [MyWorkspace]?
-      Are you sure you want to delete the workspace(s): [MyWorkspace]?
+```text
+Delete workspace(s): [MyWorkspace]?
+Are you sure you want to delete the workspace(s): [MyWorkspace]?
 
-      [Yes]   [No]
-   ```
+[Yes]   [No]
+```
 
 2. Confirm the action to delete the selected Workspace.
 
-   ```text
-      Workspace MyWorkspace successfully deleted
-   ```
+```text
+Workspace MyWorkspace successfully deleted
+```
 
 ## Forward Ports from a Workspace
 
@@ -255,19 +251,21 @@ You can access services running in a Workspace on your local machine.
 
 1. Run the following command to forward a port from a running Workspace to your local machine:
 
-   ```shell
-   daytona forward <PORT> <WORKSPACE> <PROJECT>
-   ```
+```shell
+daytona forward <PORT> <WORKSPACE> <PROJECT>
+```
 
-   **Example:** Allow local access to port 4321 of the `example-dev-env` Workspace.
+**Example:** Allow local access to port 4321 of the `example-dev-env` Workspace.
 
-   ```shell
-   daytona forward 4321 example-dev-env
-   ```
+```shell
+daytona forward 4321 example-dev-env
+```
 
-   Upon running this command, Daytona will establish a port forwarding connection from the specified port in the Workspace to your local machine. The terminal will display a message indicating the local port where the forwarded connection is available:
+Upon running this command, Daytona will establish a port forwarding connection from the specified port in the Workspace to your local machine. The terminal will display a message indicating the local port where the forwarded connection is available:
 
-   `Port available at http://localhost:4321`
+```text
+Port available at http://localhost:4321
+```
 
 ### Access a Port via Public URL
 
@@ -285,31 +283,31 @@ By using this feature, you acknowledge that your data is processed in accordance
 
 1. Run the following command to generate a public URL for a port on a running Workspace:
 
-   ```shell
-   daytona forward <PORT> <WORKSPACE> <PROJECT> --public
-   ```
+```shell
+daytona forward <PORT> <WORKSPACE> <PROJECT> --public
+```
 
-   **Example:** Generate a URL to access port 4321 of the `example-dev-env` Workspace.
+**Example:** Generate a URL to access port 4321 of the `example-dev-env` Workspace.
 
-   ```shell
-   daytona forward 4321 example-dev-env --public
-   ```
+```shell
+daytona forward 4321 example-dev-env --public
+```
 
-   Upon running this command, Daytona will first establish a local port forwarding connection and display a message indicating the local port where the forwarded connection is available.
+Upon running this command, Daytona will first establish a local port forwarding connection and display a message indicating the local port where the forwarded connection is available.
 
-   ```text
-      Port available at http://localhost:4321
-   ```
+```text
+Port available at http://localhost:4321
+```
 
-   Then, Daytona will proceed to forward the port to a public URL. The terminal will display progress information and, upon completion, provide the generated public URL.
+Then, Daytona will proceed to forward the port to a public URL. The terminal will display progress information and, upon completion, provide the generated public URL.
 
-   ```text
-      Forwarding port to a public URL...
-      Port available at:
-      https://4321-ABC1DeF2GhI3JkLmNoP4RSTuVZ5.try-eu.daytona.app
-   ```
+```text
+Forwarding port to a public URL...
+Port available at:
+https://4321-ABC1DeF2GhI3JkLmNoP4RSTuVZ5.try-eu.daytona.app
+```
 
-   This URL can be shared with others to provide real-time access to the service running on the specified port in your Workspace.
+This URL can be shared with others to provide real-time access to the service running on the specified port in your Workspace.
 
 <Aside type="tip">
 Alternatively, you can generate a public URL by executing the following command in a Workspace's shell:

--- a/src/styles/components/markdown.scss
+++ b/src/styles/components/markdown.scss
@@ -276,6 +276,7 @@
     margin-bottom: 24px;
     margin-top: 0;
     list-style-image: url(/src/assets/icons/facts.svg);
+    margin-left: 14px;
 
     @include for-mobile-screen-sizes {
       margin-bottom: 40px;


### PR DESCRIPTION
> **@ivan-burazin**
> Takoder mislim da je problem ovaj indenting
> Mozda da stavimo sve da je alignano left
> nema veze jel menu, paragraf bullet ili sub bullet sve da je alignano lijevo

Applied consistent style indentation formatting to all sections. This can be ported to the enterprise documentation too once the open pull requests are merged so it can be applied to all sections at once.

Important changes: https://github.com/daytonaio/docs/commit/e14c44a5346e7094dfab377ff22880d8748a7f38 - this commit disables the MD029 indentation rule.

Example:

Before

<img width="607" alt="Screenshot 2024-08-31 at 12 50 03 AM" src="https://github.com/user-attachments/assets/0618d7f9-72cc-4a53-b59c-e02225c084c5">

After

<img width="628" alt="Screenshot 2024-08-31 at 12 50 30 AM" src="https://github.com/user-attachments/assets/a3061ebf-efc1-4878-9d81-9ab992008c97">
