### PR TITLE
docs: fix broken links & hyperlinks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -22,6 +22,7 @@ const myThemeLight = ExpressiveCodeTheme.fromJSONString(jsonLightString)
 // https://astro.build/config
 export default defineConfig({
   site: PUBLIC_WEB_URL,
+  base: '/docs',
   integrations: [
     react(),
     starlight({

--- a/src/content/docs/about/getting-started.mdx
+++ b/src/content/docs/about/getting-started.mdx
@@ -95,7 +95,7 @@ Additionally, you can use the `daytona --help` command to list all commands, off
 <DocumentListItem
     title="CLI Reference"
     subtitle="Learn how to use the Daytona Command-Line Interface (CLI) to manage your development environments."
-    href="/reference/cli"
+    href="/docs/reference/cli"
     expanded
   />
 </DocumentList>
@@ -122,7 +122,7 @@ Use the `daytona git-providers --help` command to view available options for man
 <DocumentListItem
     title="Add a Git Provider"
     subtitle="Learn how to add a Git Provider to Daytona and start managing your repositories effectively."
-    href="/docs/configurationgit-providers#add-a-git-provider"
+    href="/docs/configurationg/git-providers#add-a-git-provider"
     expanded
   />
 </DocumentList>
@@ -165,7 +165,7 @@ Follow the instructions provided in the [Providers installation](/docs/configura
 <DocumentListItem
     title="Install a Provider"
     subtitle="Learn how to install a Provider and interface with the Daytona Server."
-    href="/docs/configurationproviders"
+    href="/docs/configuration/providers"
     expanded
   />
 </DocumentList>
@@ -186,7 +186,7 @@ Use the `daytona target --help` command to view available configuration options 
 <DocumentListItem
     title="Set a Target"
     subtitle="Learn how to set a Target to define how Daytona manages your development environment."
-    href="/docs/configurationtargets"
+    href="/docs/configuration/targets"
     expanded
   />
 </DocumentList>
@@ -217,7 +217,7 @@ Use the `daytona ide` command to view available configuration options for settin
 <DocumentListItem
     title="Set Default IDE"
     subtitle="Learn how to set your default IDE to automatically open your development environment."
-    href="/docs/usageide#set-the-default-ide"
+    href="/docs/usage/ide#set-the-default-ide"
     expanded
   />
 </DocumentList>
@@ -234,7 +234,7 @@ To create a Workspace, use the `daytona create` command and follow the prompts t
 <DocumentListItem
     title="Create a Workspace"
     subtitle="Learn how to create your Workspace using Daytona."
-    href="/docs/usageworkspaces#create-a-workspace"
+    href="/docs/usage/workspaces#create-a-workspace"
     expanded
   />
 </DocumentList>

--- a/src/content/docs/about/getting-started.mdx
+++ b/src/content/docs/about/getting-started.mdx
@@ -36,9 +36,9 @@ Daytona supports multiple operating systems and architectures. Ensure your syste
 
 | **Operating System**                         | **Architecture**                                   |
 |-----------------------------------------------| --------------------------------------------------|
-| [Linux](installation/installation#linux)      | `x86_64` or `ARM64`                               |
-| [macOS](/installation/installation#macos)     | `x86_64 (Intel-based)` or `ARM64 (Apple Silicon)` |
-| [Windows](/installation/installation#windows) | `x86_64` or `ARM64`                               |
+| [Linux](/docs/installation/installation#linux)      | `x86_64` or `ARM64`                               |
+| [macOS](/docs/installation/installation#macos)     | `x86_64 (Intel-based)` or `ARM64 (Apple Silicon)` |
+| [Windows](/docs/installation/installation#windows) | `x86_64` or `ARM64`                               |
 
 ### Dependencies
 
@@ -60,22 +60,22 @@ Daytona requires certain tools to be installed on your system to optimize the se
 
 ## Installing Daytona
 
-Follow the instructions provided in the [installation](/installation/installation) guide to install Daytona on your operating system. The guide includes detailed steps for installing Daytona on Linux, macOS, and Windows operating systems.
+Follow the instructions provided in the [installation](/docs/installation/installation) guide to install Daytona on your operating system. The guide includes detailed steps for installing Daytona on Linux, macOS, and Windows operating systems.
 
 The installation process may vary depending on your operating system and specific environment. Refer to the guide for comprehensive instructions tailored to your setup.
 
 <DocumentList>
 <DocumentListItem
     title="Linux Installation"
-    href="/installation/installation#linux"
+    href="/docs/installationinstallation#linux"
   />
   <DocumentListItem
     title="macOS Installation"
-    href="/installation/installation#macos"
+    href="/docs/installationinstallation#macos"
   />
   <DocumentListItem
     title="Windows Installation"
-    href="/installation/installation#windows"
+    href="/docs/installationinstallation#windows"
   />
 </DocumentList>
 
@@ -87,7 +87,7 @@ The Daytona Command-Line Interface (CLI) is the primary method of interacting wi
 
 To access the Daytona CLI, open your terminal and use the `daytona` command followed by the desired subcommand. The CLI offers a wide range of commands, each serving a specific purpose, such as creating Workspaces, managing Providers, setting Targets, and configuring system settings.
 
-For a complete list of available commands and their descriptions, refer to the [CLI Reference](/reference/cli). This reference guide provides detailed information on each command, including usage examples and command options, helping you leverage the full potential of the Daytona CLI.
+For a complete list of available commands and their descriptions, refer to the [CLI Reference](/docs/reference/cli). This reference guide provides detailed information on each command, including usage examples and command options, helping you leverage the full potential of the Daytona CLI.
 
 Additionally, you can use the `daytona --help` command to list all commands, offering a convenient way to explore available options.
 
@@ -102,9 +102,9 @@ Additionally, you can use the `daytona --help` command to list all commands, off
 
 ## Adding a Git Provider
 
-You can integrate Daytona with a [Git Provider](/configuration/git-providers) to manage version control operations and interact with your Git repositories.
+You can integrate Daytona with a [Git Provider](/docs/configuration/git-providers) to manage version control operations and interact with your Git repositories.
 
-Daytona supports a variety of Git Providers, including [GitHub](/configuration/git-providers#github), [GitLab](/configuration/git-providers#gitlab), [Bitbucket](/configuration/git-providers#bitbucket), [GitHub Enterprise Server](/configuration/git-providers#github-enterprise-server), [GitLab Self-Managed](/configuration/git-providers#gitlab-self-managed), [Bitbucket Server](/configuration/git-providers#bitbucket-server), [Codeberg](/configuration/git-providers#codeberg), [Gitea](/configuration/git-providers#gitea), [Gitness](/configuration/git-providers#gitness), [Azure DevOps](/configuration/git-providers#azure-devops), and [AWS CodeCommit](/configuration/git-providers#aws-codecommit).
+Daytona supports a variety of Git Providers, including [GitHub](/docs/configuration/git-providers#github), [GitLab](/docs/configuration/git-providers#gitlab), [Bitbucket](/docs/configuration/git-providers#bitbucket), [GitHub Enterprise Server](/docs/configuration/git-providers#github-enterprise-server), [GitLab Self-Managed](/docs/configuration/git-providers#gitlab-self-managed), [Bitbucket Server](/docs/configuration/git-providers#bitbucket-server), [Codeberg](/docs/configuration/git-providers#codeberg), [Gitea](/docs/configuration/git-providers#gitea), [Gitness](/docs/configuration/git-providers#gitness), [Azure DevOps](/docs/configuration/git-providers#azure-devops), and [AWS CodeCommit](/docs/configuration/git-providers#aws-codecommit).
 
 This integration supports and enables interacting with your codebase, cloning repositories, and pushing changes directly from Daytona.
 
@@ -122,14 +122,14 @@ Use the `daytona git-providers --help` command to view available options for man
 <DocumentListItem
     title="Add a Git Provider"
     subtitle="Learn how to add a Git Provider to Daytona and start managing your repositories effectively."
-    href="/configuration/git-providers#add-a-git-provider"
+    href="/docs/configurationgit-providers#add-a-git-provider"
     expanded
   />
 </DocumentList>
 
 ## Installing a Provider
 
-[Providers](/configuration/providers) are plugins through which Daytona integrates with various technologies to create and manage development environments. Providers abstract complexities of underlying technologies and serve as the foundational engines that Daytona leverages to deploy and run your environments, whether through containerization, orchestration, or cloud-based virtual machines.
+[Providers](/docs/configuration/providers) are plugins through which Daytona integrates with various technologies to create and manage development environments. Providers abstract complexities of underlying technologies and serve as the foundational engines that Daytona leverages to deploy and run your environments, whether through containerization, orchestration, or cloud-based virtual machines.
 
 By default, a Docker Provider is configured with `localhost` as the Target.
 
@@ -159,26 +159,26 @@ If this configuration meets your requirements, you can proceed with [setting a T
 
 You can install additional Providers to extend Daytona's capabilities and support a wide range of container management platforms and cloud hosting services.
 
-Follow the instructions provided in the [Providers installation](/configuration/providers) guide to install and manage a Provider. The guide includes detailed steps for installing Providers for various container management platforms and cloud hosting services.
+Follow the instructions provided in the [Providers installation](/docs/configuration/providers) guide to install and manage a Provider. The guide includes detailed steps for installing Providers for various container management platforms and cloud hosting services.
 
 <DocumentList>
 <DocumentListItem
     title="Install a Provider"
     subtitle="Learn how to install a Provider and interface with the Daytona Server."
-    href="/configuration/providers"
+    href="/docs/configurationproviders"
     expanded
   />
 </DocumentList>
 
 ## Setting a Target
 
-A [Target](/configuration/targets) refers to the specific destination or environment where your development setups, facilitated by various Providers, are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
+A [Target](/docs/configuration/targets) refers to the specific destination or environment where your development setups, facilitated by various Providers, are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
 
 A Target can be a local machine, a remote server, or a cloud instance, and it can vary based on the chosen Provider. Targets offer the flexibility to deploy and manage environments across different platforms and accounts, all within the unified interface provided by Daytona.
 
 Once you set your Target, it becomes available for selection whenever you create a new development environment in Daytona. You can manage multiple Targets or delete those you no longer need.
 
-Follow the instructions provided in the [managing Targets](/configuration/targets) guide to set a Target and configure your development environment deployment settings.
+Follow the instructions provided in the [managing Targets](/docs/configuration/targets) guide to set a Target and configure your development environment deployment settings.
 
 Use the `daytona target --help` command to view available configuration options for setting a Target.
 
@@ -186,14 +186,14 @@ Use the `daytona target --help` command to view available configuration options 
 <DocumentListItem
     title="Set a Target"
     subtitle="Learn how to set a Target to define how Daytona manages your development environment."
-    href="/configuration/targets"
+    href="/docs/configurationtargets"
     expanded
   />
 </DocumentList>
 
 ## Choosing the Default IDE
 
-Daytona allows you to connect to your development environment using a variety of [IDEs](/usage/ide), including popular options like [Visual Studio Code (VSCode)](/usage/ide#vs-code), JetBrains IDEs, and [Terminal SSH](/usage/ide#terminal-ssh).
+Daytona allows you to connect to your development environment using a variety of [IDEs](/docs/usage/ide), including popular options like [Visual Studio Code (VSCode)](/docs/usage/ide#vs-code), JetBrains IDEs, and [Terminal SSH](/docs/usage/ide#terminal-ssh).
 
 By setting the default IDE, you can automatically open your development environment in your preferred environment, optimizing your workflow and reducing setup time.
 
@@ -217,16 +217,16 @@ Use the `daytona ide` command to view available configuration options for settin
 <DocumentListItem
     title="Set Default IDE"
     subtitle="Learn how to set your default IDE to automatically open your development environment."
-    href="/usage/ide#set-the-default-ide"
+    href="/docs/usageide#set-the-default-ide"
     expanded
   />
 </DocumentList>
 
 ## Creating your Workspace
 
-Once you have completed the initial setup and configuration steps, you can [create your Workspace](/usage/workspaces#create-a-workspace) using Daytona. A Workspace represents an isolated development environment where you can manage your code, build projects, and collaborate with team members.
+Once you have completed the initial setup and configuration steps, you can [create your Workspace](/docs/usage/workspaces#create-a-workspace) using Daytona. A Workspace represents an isolated development environment where you can manage your code, build projects, and collaborate with team members.
 
-Creating a Workspace involves defining the necessary configurations, such as selecting the appropriate [Git Provider](/configuration/git-providers) or entering the Git repository URL. Daytona simplifies this process by providing a user-friendly interface to set up and manage your Workspaces.
+Creating a Workspace involves defining the necessary configurations, such as selecting the appropriate [Git Provider](/docs/configuration/git-providers) or entering the Git repository URL. Daytona simplifies this process by providing a user-friendly interface to set up and manage your Workspaces.
 
 To create a Workspace, use the `daytona create` command and follow the prompts to configure your Workspace settings. Once created, you can access your Workspace and interact with your codebase.
 
@@ -234,7 +234,7 @@ To create a Workspace, use the `daytona create` command and follow the prompts t
 <DocumentListItem
     title="Create a Workspace"
     subtitle="Learn how to create your Workspace using Daytona."
-    href="/usage/workspaces#create-a-workspace"
+    href="/docs/usageworkspaces#create-a-workspace"
     expanded
   />
 </DocumentList>

--- a/src/content/docs/about/getting-started.mdx
+++ b/src/content/docs/about/getting-started.mdx
@@ -67,15 +67,15 @@ The installation process may vary depending on your operating system and specifi
 <DocumentList>
 <DocumentListItem
     title="Linux Installation"
-    href="/docs/installationinstallation#linux"
+    href="/docs/installation/installation#linux"
   />
   <DocumentListItem
     title="macOS Installation"
-    href="/docs/installationinstallation#macos"
+    href="/docs/installation/installation#macos"
   />
   <DocumentListItem
     title="Windows Installation"
-    href="/docs/installationinstallation#windows"
+    href="/docs/installation/installation#windows"
   />
 </DocumentList>
 

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -11,7 +11,7 @@ import DocumentListItem from "@components/DocumentListItem.astro";
 
 Providers are plugins through which Daytona integrates with various technologies to create and manage development environments. Providers abstract complexities of underlying technologies and serve as the foundational engines that Daytona leverages to deploy and run your environments, whether through containerization, orchestration, or cloud-based virtual machines.
 
-Daytona's architecture decentralizes the role of a Provider into a separate service. The [Daytona Server](/usage/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
+Daytona's architecture decentralizes the role of a Provider into a separate service. The [Daytona Server](/docs/usage/server) communicates with Providers to execute operations relating to Workspace creation and lifecycle management.
 
 ## Install a Provider
 
@@ -41,7 +41,7 @@ v0.0.0
 Select a specific version
 ```
 
-Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces. You can now create a [Target](/configuration/targets) to use with the created Provider.
+Upon selecting the Provider, Daytona will install and configure the chosen Provider, making it available for managing and deploying Workspaces. You can now create a [Target](/docs/configuration/targets) to use with the created Provider.
 
 ```text
 Provider docker-provider has been successfully installed
@@ -115,7 +115,7 @@ Provider docker-provider has been successfully uninstalled
 
 ## Docker
 
-The Docker Provider allows Daytona to create Workspace projects as Docker containers. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
+The Docker Provider allows Daytona to create Workspace projects as Docker containers. Daytona installs a Provider for Docker (`docker-provider`) by default and adds a default [Target](/docs/configuration/targets#docker) using the Docker Provider, allowing the creation of Workspaces on your local machine.
 
 1. Run the following command to install a Docker Provider:
 
@@ -146,7 +146,7 @@ Provider docker-provider has been successfully installed
 <DocumentListItem
     title="Set a Docker Target"
     subtitle="Learn how to set a local or remote Docker Target to deploy and manage Workspaces."
-    href="/configuration/targets#docker"
+    href="/docs/configurationtargets#docker"
     expanded
   />
 </DocumentList>
@@ -186,7 +186,7 @@ Provider aws-provider has been successfully installed
 <DocumentListItem
     title="Set an AWS Target"
     subtitle="Learn how to set an AWS Target to deploy and manage Workspaces."
-    href="/configuration/targets#aws"
+    href="/docs/configurationtargets#aws"
     expanded
   />
 </DocumentList>
@@ -224,7 +224,7 @@ Provider digitalocean-provider has been successfully installed
 <DocumentListItem
     title="Set a DigitalOcean Target"
     subtitle="Learn how to set a DigitalOcean Target to deploy and manage Workspaces."
-    href="/configuration/targets#digitalocean"
+    href="/docs/configurationtargets#digitalocean"
     expanded
   />
 </DocumentList>
@@ -262,7 +262,7 @@ Provider fly-provider has been successfully installed
 <DocumentListItem
     title="Set a Fly Target"
     subtitle="Learn how to set a Fly Target to deploy and manage Workspaces."
-    href="/configuration/targets#fly"
+    href="/docs/configurationtargets#fly"
     expanded
   />
 </DocumentList>

--- a/src/content/docs/configuration/providers.mdx
+++ b/src/content/docs/configuration/providers.mdx
@@ -224,7 +224,7 @@ Provider digitalocean-provider has been successfully installed
 <DocumentListItem
     title="Set a DigitalOcean Target"
     subtitle="Learn how to set a DigitalOcean Target to deploy and manage Workspaces."
-    href="/docs/configurationtargets#digitalocean"
+    href="/docs/configuration/targets#digitalocean"
     expanded
   />
 </DocumentList>
@@ -262,7 +262,7 @@ Provider fly-provider has been successfully installed
 <DocumentListItem
     title="Set a Fly Target"
     subtitle="Learn how to set a Fly Target to deploy and manage Workspaces."
-    href="/docs/configurationtargets#fly"
+    href="/docs/configuration/targets#fly"
     expanded
   />
 </DocumentList>

--- a/src/content/docs/configuration/targets.mdx
+++ b/src/content/docs/configuration/targets.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Targets
 ---
 
-A Target refers to the specific destination or environment where your development setups, facilitated by various [Providers](/configuration/providers), are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
+A Target refers to the specific destination or environment where your development setups, facilitated by various [Providers](/docs/configuration/providers), are deployed and managed. Providers define the method and technology used to create your environments, while Targets specify the precise location or platform where these environments will reside.
 
 A Target can be a local machine, a remote server, or a cloud instance, and it can vary based on the chosen Provider. Targets offer the flexibility to deploy and manage environments across different platforms and accounts, all within the unified interface provided by Daytona.
 
@@ -17,7 +17,7 @@ Daytona allows you to set a Target to use when managing Workspaces.
 
 **Prerequisite**
 
-- **At least [one Provider installed](/configuration/providers).**
+- **At least [one Provider installed](/docs/configuration/providers).**
 
     Providers are essential for managing and deploying your Workspaces, so make sure you have configured at least one.
 

--- a/src/content/docs/installation/installation.mdx
+++ b/src/content/docs/installation/installation.mdx
@@ -17,7 +17,7 @@ import UninstallUnix from './method/uninstall-unix.mdx'
 You can install Daytona on [Linux](#linux), [macOS](#macos), and [Windows](#windows) systems.
 Each operating system supports both x86_64 and AArch64 architectures.
 
-After installing Daytona using the best method for your environment, you can [create a Workspace](/usage/workspaces#create-a-workspace), [add a Git Provider](/configuration/git-providers#add-a-git-provider), [install a Provider](/configuration/providers#install-a-provider), and [use the CLI reference](/reference/cli) to understand Daytona's full array of functionality.
+After installing Daytona using the best method for your environment, you can [create a Workspace](/docs/usage/workspaces#create-a-workspace), [add a Git Provider](/docs/configuration/git-providers#add-a-git-provider), [install a Provider](/docs/configuration/providers#install-a-provider), and [use the CLI reference](/docs/reference/cli) to understand Daytona's full array of functionality.
 
 ## Linux
 

--- a/src/content/docs/usage/builders.mdx
+++ b/src/content/docs/usage/builders.mdx
@@ -10,7 +10,7 @@ import Aside from '@components/Aside.astro'
 Builders are responsible for creating a container image with everything you need to be productive.
 Daytona provides control over how the resulting Project environment is created, allowing you to choose your preferred method to pull in your project's tools, dependencies, and configuration.
 
-When [creating a Workspace](./workspaces#create-a-workspace), you can choose between the following Builders during the Advanced Configuration step:
+When [creating a Workspace](/docs/usage/workspaces#create-a-workspace), you can choose between the following Builders during the Advanced Configuration step:
 
 1. [**Automatic**](#automatic-builder)
 

--- a/src/content/docs/usage/builders.mdx
+++ b/src/content/docs/usage/builders.mdx
@@ -37,7 +37,7 @@ When choosing this option, Daytona uses the following logic to determine which B
 2. If present, use the [Dev Container Builder](#dev-container-builder).
 3. If not present, use the [None Builder](#none).
 
-To use the Automatic Builder, set the `--builder` flag value to `auto` during the [Workspace creation](/usage/workspaces#create-a-workspace). This flag only applies when creating Workspaces with a single Project.
+To use the Automatic Builder, set the `--builder` flag value to `auto` during the [Workspace creation](/docs/usage/workspaces#create-a-workspace). This flag only applies when creating Workspaces with a single Project.
 
 ```shell
 daytona create <REPO_URL> --builder=auto
@@ -53,7 +53,7 @@ The following option is available when using this Builder:
 The path where the Dev Container configuration is located, relative to the repository root.
 The default value is `.devcontainer/devcontainer.json`.
 
-To use the Dev Container Builder, set the `--devcontainer-path` flag to the Dev Container configuration path within the repository during the [Workspace creation](/usage/workspaces#create-a-workspace). This flag only applies when creating Workspaces with a single Project.
+To use the Dev Container Builder, set the `--devcontainer-path` flag to the Dev Container configuration path within the repository during the [Workspace creation](/docs/usage/workspaces#create-a-workspace). This flag only applies when creating Workspaces with a single Project.
 
 ```shell
 daytona create <REPO_URL> --devcontainer-path=.devcontainer/devcontainer.json
@@ -86,7 +86,7 @@ Commands to execute once the Project is started.
 4. **Environment variables**
 A list of environment variables in the format `KEY=VALUE`.
 
-To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags during the [Workspace creation](/usage/workspaces#create-a-workspace). These flags only apply when creating Workspaces with a single Project.
+To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags during the [Workspace creation](/docs/usage/workspaces#create-a-workspace). These flags only apply when creating Workspaces with a single Project.
 
 ```shell
 daytona create <REPO_URL> --custom-image=daytona-workspace:latest --custom-image-user=daytona

--- a/src/content/docs/usage/ide.mdx
+++ b/src/content/docs/usage/ide.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 import Aside from '@components/Aside.astro'
 
-Daytona allows you to connect to your [Workspace](/usage/workspaces#open-an-existing-workspace) using your default IDE.
+Daytona allows you to connect to your [Workspace](/docs/usage/workspaces#open-an-existing-workspace) using your default IDE.
 
 Out of the box, Daytona can be configured to open your Workspace in the following IDEs:
 

--- a/src/content/docs/usage/prebuilds.mdx
+++ b/src/content/docs/usage/prebuilds.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 Prebuilds are designed to accelerate development by pre-building your Workspace. When you start a Workspace, the prebuilt environment is used, ensuring that the Workspace is initiated almost instantly.
 
-Prebuilds achieve this by setting up a [project configuration](/usage/projects#project-configuration) that monitors changes in the connected Git Provider's repository.
+Prebuilds achieve this by setting up a [project configuration](/docs/usage/projects#project-configuration) that monitors changes in the connected Git Provider's repository.
 
 Prebuilds work by registering a listener for webhook events from the Git Provider. A public API endpoint is provided, which the Git Provider uses to send these requests.
 
@@ -49,7 +49,7 @@ Subsequent `daytona create` calls will automatically detect the most recent exis
 
 ## Use a Prebuild
 
-Once you added a Prebuild, it becomes active immediately based on the [project configuration](usage/projects#project-configuration) you provided. The Prebuild will automatically run whenever the specified conditions are met, such as when the defined number of commits is reached.
+Once you added a Prebuild, it becomes active immediately based on the [project configuration](/docs/usage/projects#project-configuration) you provided. The Prebuild will automatically run whenever the specified conditions are met, such as when the defined number of commits is reached.
 
 For instance, if you specified a commit interval of `5`, the Prebuild will run after every `5` commits to the repository. Populate the **Trigger files** field with files whose changes you want to immediately trigger a Prebuild, without having to wait for the commit interval. Use the **Retention** field to define how many successful builds you want Daytona to remember (defaults to `3`).
 

--- a/src/content/docs/usage/projects.mdx
+++ b/src/content/docs/usage/projects.mdx
@@ -23,10 +23,10 @@ A project configuration encapsulates all the essential elements for setting up a
 
 - **Build Configuration**
 
-  - [Automatic](/usage/builders#automatic-builder) auto-detects the most appropriate Builder for your project.
-  - [Devcontainer](/usage/builders#dev-container-builder) utilizes a predefined development container specified by a `devcontainer.json` file.
-  - [Custom image](/usage/builders#custom-image-builder) builds the Project image by specifying a custom base container.
-  - [None](/usage/builders#none) builds a Project by using the default base image (`daytonaio/workspace-project`).
+  - [Automatic](/docs/usage/builders#automatic-builder) auto-detects the most appropriate Builder for your project.
+  - [Devcontainer](/docs/usage/builders#dev-container-builder) utilizes a predefined development container specified by a `devcontainer.json` file.
+  - [Custom image](/docs/usage/builders#custom-image-builder) builds the Project image by specifying a custom base container.
+  - [None](/docs/usage/builders#none) builds a Project by using the default base image (`daytonaio/workspace-project`).
 
 - **Environment Variables**
 

--- a/src/content/docs/usage/server.mdx
+++ b/src/content/docs/usage/server.mdx
@@ -5,7 +5,7 @@ sidebar:
   label: Server 
 ---
 
-The Daytona Server is a daemon that runs on your machine and handles [Workspaces](/usage/workspaces) related actions.
+The Daytona Server is a daemon that runs on your machine and handles [Workspaces](/docs/usage/workspaces) related actions.
 It provides capabilities for [starting](#start-the-server), [configuring](#configure-the-server), and [stopping](#stop-the-server) server operations.
 The primary method of interacting with the server is through the Daytona CLI. Users can also interact with the Daytona Server using its HTTP interface.
 

--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -17,7 +17,7 @@ Creating your own Workspace in Daytona is a straightforward process that ensures
 
 **Prerequisite**
 
-- **At least [one Target configured](/configuration/targets)**.
+- **At least [one Target configured](/docs/configuration/targets)**.
 
   Targets are essential for deploying your Workspaces, so make sure you have configured at least one.
 
@@ -32,7 +32,7 @@ daytona create
 ```
 
 <Aside type="tip">
-You can open a new Workspace in an [IDE](/usage/ide) by using the `--code` flag.
+You can open a new Workspace in an [IDE](/docs/usage/ide) by using the `--code` flag.
 
 ```shell
 daytona create --code
@@ -66,7 +66,7 @@ Enter a custom repository URL
 
 <Aside type="note">
    You can press `F10` to configure advanced settings for your Workspace,
-   including setting the [Builder](/usage/builders).
+   including setting the [Builder](/docs/usage/builders).
 </Aside>
 
 <br />
@@ -117,7 +117,7 @@ daytona   | Project daytona started
 
 <Aside type="tip">
 You can set the Project Builder at Workspace creation time using command-line
-flags. Refer to **[Builders](/usage/builders)** for more information.
+flags. Refer to **[Builders](/docs/usage/builders)** for more information.
 </Aside>
 
 ## List Workspaces
@@ -163,7 +163,7 @@ Select a Workspace To Open
 
 :::note
 You can configure Daytona to use your preferred IDE.
-Refer to **[Set the Default IDE](/usage/ide#set-the-default-ide)** for more information.
+Refer to **[Set the Default IDE](/docs/usage/ide#set-the-default-ide)** for more information.
 :::
 
 ## Delete Workspaces


### PR DESCRIPTION
This should fix the broken links & hyperlinks in the deployed and local documentation.