### PR TITLE
fix: remove hardcoded directory in devcontainer.json file

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
     4321
   ],
   "workspaceFolder": "/workspaces/docs",
-  "onCreateCommand": "sudo cp /workspaces/docs/.devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt",
+  "onCreateCommand": "sudo cp ${containerWorkspaceFolder}/.devcontainer/welcome-message.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt",
   "postCreateCommand": "yarn install",
   "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
   "remoteUser": "daytona"


### PR DESCRIPTION
# Remove hardcoded directory in devcontainer.json file

## Description
This PR removes the hardcoded directory from devcontainer.json file which was causing the OnCreateCommand to fail when trying to run docs from Daytona OSS.

## Screenshots
