### PR TITLE
fix: remove post start commands description

### DIFF
--- a/src/content/docs/usage/builders.mdx
+++ b/src/content/docs/usage/builders.mdx
@@ -79,11 +79,7 @@ The name of the base container image for the Project.
 
 The user to execute commands as during the image build process.
 
-3. **Post start commands**
-
-Commands to execute once the Project is started.
-
-4. **Environment variables**
+3. **Environment variables**
 A list of environment variables in the format `KEY=VALUE`.
 
 To use the Custom Image Builder, set both `--custom-image` and `--custom-image-user` flags during the [Workspace creation](/docs/usage/workspaces#create-a-workspace). These flags only apply when creating Workspaces with a single Project.


### PR DESCRIPTION
Removed the Post Start Commands description from the Custom Image Builder. The start commands were removed from Daytona.