### PR TITLE
fix: replace --code tip with --no-ide

### DIFF
--- a/src/content/docs/usage/workspaces.mdx
+++ b/src/content/docs/usage/workspaces.mdx
@@ -32,10 +32,10 @@ daytona create
 ```
 
 <Aside type="tip">
-You can open a new Workspace in an [IDE](/docs/usage/ide) by using the `--code` flag.
+You can skip automatically opening the Workspace in an [IDE](/docs/usage/ide) by using the `--no-ide` flag.
 
 ```shell
-daytona create --code
+daytona create --no-ide
 ```
 
 </Aside>


### PR DESCRIPTION
In regards to https://github.com/daytonaio/daytona/pull/1205, replaced the `--code` tip with `--no-ide`