### PR TITLE
docs(style): green code/blockquote text value

### DIFF
--- a/src/styles/_color.scss
+++ b/src/styles/_color.scss
@@ -41,5 +41,5 @@ html[data-theme="light"] body {
   --darken-secondary-text-color: #424242;
   --blue-link: #005fbe;
   --cta-surface-neutral-primary: #dedede;
-
+  --hover-color: #08ae78;
 }

--- a/src/styles/components/markdown.scss
+++ b/src/styles/components/markdown.scss
@@ -89,7 +89,7 @@
       letter-spacing: -0.04em;
       border: 0.5px solid var(--border-extra);
       padding: 2px 6px;
-      color: var(--primary-text-color);
+      color: var(--hover-color);
       background-color: var(--block-bg-color);
       border-radius: 4px;
       white-space: nowrap;
@@ -302,7 +302,7 @@
         font-size: 0.88rem;
         font-weight: 400;
         line-height: 1.4;
-        color: var(--primary-text-color);
+        color: var(--hover-color);
         letter-spacing: -0.02em;
         background-color: var(--block-bg-color);
         padding: 0.1rem 0.4rem;


### PR DESCRIPTION
To match the Dotfiles Insider blog.

<img width="684" alt="green" src="https://github.com/user-attachments/assets/aa455d2a-4154-4aab-a147-b097104b1270">
