### PR TITLE
docs: fix sdk index

### DIFF
--- a/src/content/docs/sdk/index.mdx
+++ b/src/content/docs/sdk/index.mdx
@@ -33,7 +33,7 @@ import DocumentListItem from "@components/DocumentListItem.astro";
   <DocumentListItem
     title="File System Operations"
     subtitle="Learn how to manage files and directories in your Workspaces using the Daytona SDK."
-    href="/file-system-operations"
+    href="/docs/sdk/file-system-operations"
   />
   <DocumentListItem
     title="Git Operations"

--- a/src/content/docs/sdk/index.mdx
+++ b/src/content/docs/sdk/index.mdx
@@ -12,12 +12,12 @@ import DocumentListItem from "@components/DocumentListItem.astro";
   <DocumentListItem
     title="Getting Started"
     subtitle="Learn about Daytona SDK and how it can help you manage your development environments."
-    href="/getting-started"
+    href="/docs/sdk/getting-started"
   />
   <DocumentListItem
     title="Configuration"
     subtitle="Get started with Daytona SDK and learn how to use and configure your development environments."
-    href="/configuration"
+    href="/docs/sdk/configuration"
   />
 </DocumentList>
 
@@ -25,7 +25,7 @@ import DocumentListItem from "@components/DocumentListItem.astro";
   <DocumentListItem
     title="Management"
     subtitle="Learn how to create, manage, and remove workspaces using the Daytona SDK."
-    href="/workspace-management"
+    href="/docs/sdk/workspace-management"
   />
 </DocumentList>
 
@@ -38,16 +38,16 @@ import DocumentListItem from "@components/DocumentListItem.astro";
   <DocumentListItem
     title="Git Operations"
     subtitle="Learn how to manage Git repositories in your Workspaces using the Daytona SDK."
-    href="/git-operations"
+    href="/docs/sdk/git-operations"
   />
   <DocumentListItem
     title="Process & Code Execution"
     subtitle="Learn about running commands and code in isolated environments using the Daytona SDK."
-    href="/process-code-execution"
+    href="/docs/sdk/process-code-execution"
   />
   <DocumentListItem
     title="Language Server Protocol"
     subtitle="Learn how to use Language Server Protocol (LSP) support in your Workspaces using the Daytona SDK."
-    href="/language-server-protocol"
+    href="/docs/sdk/language-server-protocol"
   />
 </DocumentList>


### PR DESCRIPTION
The previous solution works on localhost, but doesn't seem to properly recognize the sdk paths when deployed. This pull request should fix the paths issue as it redirects from the root (daytona.io) to the `/docs/sdk/` paths.

@Tpuljak @ivan-burazin 