### PR TITLE
refactor: set max heading level to 4 for toc sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -115,7 +115,7 @@ export default defineConfig({
           ],
         },
       ],
-      tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 2 },
+      tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 4 },
       customCss: ['./src/fonts/font-face.css', './src/styles/style.scss'],
       components: {
         Footer: './src/components/Footer.astro',

--- a/src/components/TableOfContentsList.astro
+++ b/src/components/TableOfContentsList.astro
@@ -14,7 +14,7 @@ const { toc, isMobile = false, depth = 0 } = Astro.props
   {
     toc.map(heading => (
       <li>
-        <a href={'#' + heading.slug}>
+        <a href={'#' + heading.slug} style={`padding-left: ${depth * 8}px;`}>
           <span>{heading.text}</span>
         </a>
         {heading.children.length > 0 && (


### PR DESCRIPTION
Closes #263 

ToC sidebar before:
![image](https://github.com/user-attachments/assets/db8bb365-1e9c-47b9-926d-677673cf2a7f)

ToC sidebar after:
![image](https://github.com/user-attachments/assets/1854c560-4baf-4cc7-a907-110e4b3fa05d)
