### PR TITLE
fix: temporarily hide CLI ref from menu

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -36,14 +36,14 @@ const mainNavItems = [
       icon: 'server.svg',
     },
   },
-  {
-    type: 'link',
-    href: '/docs/tools/cli',
-    label: 'CLI Reference',
-    attrs: {
-      icon: 'terminal.svg',
-    },
-  },
+  // {
+  //   type: 'link',
+  //   href: '/docs/tools/cli',
+  //   label: 'CLI Reference',
+  //   attrs: {
+  //     icon: 'terminal.svg',
+  //   },
+  // },
 ]
 
 // TypeScript SDK specific sidebar


### PR DESCRIPTION
Temporarily hiding CLI ref from the main menu until the installation and usage steps are specified