### PR TITLE
fix: Replace broken code using `sandbox.instance.state`

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -2536,11 +2536,11 @@ sandbox_id = sandbox.id
 
 root_dir = sandbox.get_user_root_dir()
 
-# Get the Sandbox name, image and state
+# Get the Sandbox image and state
 
-name = sandbox.instance.name
-image = sandbox.instance.image
-state = sandbox.instance.state
+info = sandbox.info()
+image = info.image
+state = info.state
 
 ```
 ```typescript
@@ -2550,10 +2550,10 @@ const sandboxId = sandbox.id;
 // Get the root directory of tha Sandbox user
 const rootDir = await sandbox.getSandboxRootDir();
 
-// Get the Sandbox name, image and state
-const name = sandbox.instance.name
-const image = sandbox.instance.image
-const state = sandbox.instance.state
+// Get the Sandbox image and state
+const info = await sandbox.info()
+const image = info.image
+const state = info.state
 
 ```
 

--- a/src/content/docs/sandbox-management.mdx
+++ b/src/content/docs/sandbox-management.mdx
@@ -139,11 +139,11 @@ sandbox_id = sandbox.id
 
 root_dir = sandbox.get_user_root_dir()
 
-# Get the Sandbox name, image and state
+# Get the Sandbox image and state
 
-name = sandbox.instance.name
-image = sandbox.instance.image
-state = sandbox.instance.state
+info = sandbox.info()
+image = info.image
+state = info.state
 
 ```
 </TabItem>
@@ -155,10 +155,10 @@ const sandboxId = sandbox.id;
 // Get the root directory of tha Sandbox user
 const rootDir = await sandbox.getSandboxRootDir();
 
-// Get the Sandbox name, image and state
-const name = sandbox.instance.name
-const image = sandbox.instance.image
-const state = sandbox.instance.state
+// Get the Sandbox image and state
+const info = await sandbox.info()
+const image = info.image
+const state = info.state
 
 ```
 


### PR DESCRIPTION
This PR updates code examples in both TypeScript and Python to use `sandbox.instance.state()` instead of `sandbox.instance.state`.

The example using `sandbox.instance.state` does not work as shown in https://github.com/daytonaio/daytona/issues/2022.

I created this as separate PR since it is more urgent than general improvements to documentation.